### PR TITLE
Preserve website urls and products on refresh

### DIFF
--- a/shop/backend/src/routes/adminCategories.js
+++ b/shop/backend/src/routes/adminCategories.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import Category from '../models/Category.js';
+import { saveMockData } from '../utils/mockStore.js';
 
 const router = Router({ mergeParams: true });
 
@@ -26,6 +27,7 @@ router.post('/', requireAuth, async (req, res) => {
 		if (mock) {
 			const created = { _id: `c-${Date.now()}`, ...req.body, site: siteId };
 			mock.categories.unshift(created);
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.status(201).json(created);
 		}
 		const payload = { ...req.body, site: siteId };
@@ -45,6 +47,7 @@ router.patch('/:id', requireAuth, async (req, res) => {
 			if (idx === -1) return res.status(404).json({ error: 'Not found' });
 			const updated = { ...mock.categories[idx], ...req.body };
 			mock.categories[idx] = updated;
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.json(updated);
 		}
 		const updated = await Category.findOneAndUpdate({ _id: id, site: siteId }, req.body, { new: true });
@@ -63,6 +66,7 @@ router.delete('/:id', requireAuth, async (req, res) => {
 			const before = mock.categories.length;
 			mock.categories = mock.categories.filter((c) => !(c._id === id && c.site === siteId));
 			if (mock.categories.length === before) return res.status(404).json({ error: 'Not found' });
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.status(204).end();
 		}
 		const result = await Category.findOneAndDelete({ _id: id, site: siteId });

--- a/shop/backend/src/routes/adminProducts.js
+++ b/shop/backend/src/routes/adminProducts.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import Product from '../models/Product.js';
 import Category from '../models/Category.js';
+import { saveMockData } from '../utils/mockStore.js';
 
 const router = Router({ mergeParams: true });
 
@@ -35,6 +36,7 @@ router.post('/', requireAuth, async (req, res) => {
 			if (!catOk) return res.status(400).json({ error: 'Invalid category for site' });
 			const created = { _id: `p-${Date.now()}`, ...payload };
 			mock.products.unshift(created);
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.status(201).json(created);
 		}
 		const payload = { ...req.body, site: siteId };
@@ -61,6 +63,7 @@ router.put('/:id', requireAuth, async (req, res) => {
 			if (idx === -1) return res.status(404).json({ error: 'Not found' });
 			const product = { ...mock.products[idx], ...update };
 			mock.products[idx] = product;
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.json(product);
 		}
 		const update = { ...req.body };
@@ -84,6 +87,7 @@ router.delete('/:id', requireAuth, async (req, res) => {
 			const before = mock.products.length;
 			mock.products = mock.products.filter((p) => !(p._id === id && p.site === siteId));
 			if (mock.products.length === before) return res.status(404).json({ error: 'Not found' });
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.status(204).end();
 		}
 		const result = await Product.findOneAndDelete({ _id: id, site: siteId });

--- a/shop/backend/src/routes/adminSites.js
+++ b/shop/backend/src/routes/adminSites.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import Site from '../models/Site.js';
+import { saveMockData } from '../utils/mockStore.js';
 
 const router = Router();
 
@@ -25,6 +26,7 @@ router.post('/', requireAuth, async (req, res) => {
 		if (mock) {
 			const created = { _id: `site-${Date.now()}`, name, slug, domains: domains || [], uberCustomerId, pickup, isActive: true };
 			mock.sites.unshift(created);
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.status(201).json(created);
 		}
 		const site = await Site.create({ name, slug, domains: domains || [], uberCustomerId, pickup, isActive: true });
@@ -44,6 +46,7 @@ router.patch('/:siteId', requireAuth, async (req, res) => {
 			if (idx === -1) return res.status(404).json({ error: 'Not found' });
 			const updated = { ...mock.sites[idx], ...(name !== undefined ? { name } : {}), ...(slug !== undefined ? { slug } : {}), ...(domains !== undefined ? { domains } : {}), ...(isActive !== undefined ? { isActive } : {}), ...(uberCustomerId !== undefined ? { uberCustomerId } : {}), ...(pickup !== undefined ? { pickup } : {}) };
 			mock.sites[idx] = updated;
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.json(updated);
 		}
 		const site = await Site.findByIdAndUpdate(siteId, { name, slug, domains, isActive, uberCustomerId, pickup }, { new: true });
@@ -64,6 +67,7 @@ router.delete('/:siteId', requireAuth, async (req, res) => {
 			if (mock.sites.length === before) return res.status(404).json({ error: 'Not found' });
 			mock.categories = mock.categories.filter((c) => c.site !== siteId);
 			mock.products = mock.products.filter((p) => p.site !== siteId);
+			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.status(204).end();
 		}
 		await Site.findByIdAndDelete(siteId);

--- a/shop/backend/src/server.js
+++ b/shop/backend/src/server.js
@@ -15,6 +15,7 @@ import adminUberRouter from './routes/adminUber.js';
 import Site from './models/Site.js';
 import Category from './models/Category.js';
 import Product from './models/Product.js';
+import { loadMockData, saveMockData } from './utils/mockStore.js';
 
 dotenv.config();
 
@@ -29,6 +30,11 @@ const USE_MOCK_DATA = process.env.USE_MOCK_DATA === 'true';
 
 
 if (USE_MOCK_DATA) {
+	const persisted = (typeof loadMockData === 'function') ? loadMockData() : null;
+	if (persisted) {
+		app.locals.mockData = persisted;
+		console.log('Running with mock data (persisted). Set USE_MOCK_DATA=false to use MongoDB.');
+	} else {
 	const mockSites = [
 		{ _id: 'mock-site', name: 'Default Site', slug: 'default', isActive: true },
 	];
@@ -122,6 +128,8 @@ if (USE_MOCK_DATA) {
 
 	app.locals.mockData = { sites: mockSites, categories: categoriesWithSite, products: productsWithSite };
 	console.log('Running with mock data. Set USE_MOCK_DATA=false to use MongoDB.');
+		if (typeof saveMockData === 'function') saveMockData(app.locals.mockData);
+	}
 } else {
 	if (!MONGO_URI) {
 		console.warn('No MONGO_URI set. To run without Mongo, set USE_MOCK_DATA=true.');

--- a/shop/backend/src/utils/mockStore.js
+++ b/shop/backend/src/utils/mockStore.js
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+
+// Determines the JSON file used to persist mock data
+const DEFAULT_FILE = process.env.MOCK_DB_FILE
+	? path.resolve(process.env.MOCK_DB_FILE)
+	: path.resolve(process.cwd(), 'data', 'mockData.json');
+
+export function loadMockData() {
+	try {
+		const file = DEFAULT_FILE;
+		if (!fs.existsSync(file)) return null;
+		const text = fs.readFileSync(file, 'utf-8');
+		const data = JSON.parse(text);
+		if (!data || typeof data !== 'object') return null;
+		// Basic shape guard
+		if (!Array.isArray(data.sites) || !Array.isArray(data.categories) || !Array.isArray(data.products)) {
+			return null;
+		}
+		return data;
+	} catch (_err) {
+		return null;
+	}
+}
+
+export function saveMockData(data) {
+	try {
+		const file = DEFAULT_FILE;
+		const dir = path.dirname(file);
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(file, JSON.stringify(data, null, 2));
+	} catch (_err) {
+		// Swallow errors to avoid crashing in environments without writable FS
+	}
+}
+


### PR DESCRIPTION
Implement file-based persistence for mock data to prevent sites, categories, and products from disappearing after refresh or login in the admin panel when `USE_MOCK_DATA` is enabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-13975264-1e7b-482e-a113-a6580cb16e09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13975264-1e7b-482e-a113-a6580cb16e09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

