### PR TITLE
Animate modal buttons and fix takeout location error

### DIFF
--- a/shop/backend/src/middleware/auth.js
+++ b/shop/backend/src/middleware/auth.js
@@ -35,7 +35,8 @@ export function requireUser(req, res, next) {
   if (!token) return res.status(401).json({ error: 'Missing token' });
   try {
     const payload = jwt.verify(token, JWT_SECRET);
-    if (payload?.role !== 'user') return res.status(403).json({ error: 'Forbidden' });
+    // Allow both 'user' and 'admin' roles to place pickup orders
+    if (payload?.role !== 'user' && payload?.role !== 'admin') return res.status(403).json({ error: 'Forbidden' });
     req.user = payload;
     next();
   } catch (err) {

--- a/shop/backend/src/routes/shopOrders.js
+++ b/shop/backend/src/routes/shopOrders.js
@@ -21,7 +21,7 @@ router.get('/:slug/orders/mine', requireUser, async (req, res) => {
   }
 });
 
-// Create a pickup order (no Uber delivery). Requires user auth.
+// Create a pickup order (no Uber delivery). Requires user or admin auth.
 router.post('/:slug/orders/pickup', requireUser, async (req, res) => {
   try {
     const { items, totalCents, tipCents, pickup } = req.body || {};

--- a/shop/frontend/src/components/AddToCartToast.jsx
+++ b/shop/frontend/src/components/AddToCartToast.jsx
@@ -46,6 +46,9 @@ export const AddToCartToast = () => {
         <div style={{ display: 'grid', gap: 2 }}>
           <div style={{ fontWeight: 800, letterSpacing: '.01em' }}>{msg}</div>
           {lastAdded ? <div className="muted" style={{ fontSize: 12 }}>${lastAdded.price.toFixed(2)} each</div> : null}
+          {lastAdded?.optionsSummary ? (
+            <div className="muted" style={{ fontSize: 11, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{lastAdded.optionsSummary}</div>
+          ) : null}
           <div style={{ height: 3, background: 'rgba(2,6,23,0.10)', borderRadius: 9999, overflow: 'hidden', marginTop: 6 }}>
             <div style={{ width: `${progress}%`, height: '100%', background: 'linear-gradient(90deg, var(--primary-alpha-25), var(--primary-alpha-12))' }} />
           </div>

--- a/shop/frontend/src/components/ExtrasModal.jsx
+++ b/shop/frontend/src/components/ExtrasModal.jsx
@@ -114,8 +114,8 @@ export const ExtrasModal = ({ open, groups = [], onCancel, onConfirm, product })
         })}
       </div>
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 12, marginTop: 16 }}>
-        <button onClick={onCancel} style={{ padding: '10px 14px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--panel-2)' }}>Cancel</button>
-        <button disabled={!canConfirm()} onClick={handleConfirm} className="primary-btn" style={{ padding: '10px 14px', borderRadius: 8, opacity: canConfirm() ? 1 : 0.7 }}>Add</button>
+        <button onClick={onCancel} className="hover-float" style={{ padding: '10px 14px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--panel-2)' }}>Cancel</button>
+        <button disabled={!canConfirm()} onClick={handleConfirm} className="primary-btn hover-float" style={{ padding: '10px 14px', borderRadius: 8, opacity: canConfirm() ? 1 : 0.7 }}>Add</button>
       </div>
     </Modal>
   );

--- a/shop/frontend/src/components/ProductList.jsx
+++ b/shop/frontend/src/components/ProductList.jsx
@@ -80,7 +80,7 @@ export const ProductList = ({ category, onAdd, onBack, siteSlug = 'default', veg
                 <div style={{ fontWeight: 900, color: 'var(--primary-600)' }}>${p.price.toFixed(2)}</div>
                 <button
                   onClick={() => { setActiveProduct(p); setQuickAddOpen(true); }}
-                  className="primary-btn"
+                  className="primary-btn hover-float"
                   aria-label={`Add ${p.name}`}
                   title={`Add ${p.name}`}
                   style={{ borderRadius: 999, width: 38, height: 38, padding: 0, display: 'grid', placeItems: 'center' }}

--- a/shop/frontend/src/components/QuickAddModal.jsx
+++ b/shop/frontend/src/components/QuickAddModal.jsx
@@ -1,16 +1,22 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Modal } from './Modal';
 
 export const QuickAddModal = ({ open, product, onCancel, onConfirm }) => {
   const [qty, setQty] = useState(1);
+  const [bump, setBump] = useState(false);
   if (!product) return null;
 
-  function dec() { setQty((q) => Math.max(1, q - 1)); }
-  function inc() { setQty((q) => Math.min(99, q + 1)); }
+  function triggerBump() {
+    setBump(true);
+    // Reset after animation
+    setTimeout(() => setBump(false), 200);
+  }
+  function dec() { setQty((q) => { const next = Math.max(1, q - 1); if (next !== q) triggerBump(); return next; }); }
+  function inc() { setQty((q) => { const next = Math.min(99, q + 1); if (next !== q) triggerBump(); return next; }); }
 
   return (
     <Modal open={open} onClose={onCancel} title={null}>
-      <div style={{ display: 'grid', gap: 12 }}>
+      <div style={{ display: 'grid', gap: 12 }} className="animate-popIn">
         <div style={{ position: 'relative', height: 180, borderRadius: 14, overflow: 'hidden', border: '1px solid var(--border)' }}>
           {product.imageUrl ? (
             <img src={product.imageUrl} alt={product.name} className="img-cover" />
@@ -27,15 +33,15 @@ export const QuickAddModal = ({ open, product, onCancel, onConfirm }) => {
         <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center', gap: 12 }}>
           <div className="muted" style={{ fontSize: 13 }}>{product.description || 'Add this to your order'}</div>
           <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, border: '1px solid var(--border)', borderRadius: 999, padding: 6, background: 'var(--panel-2)' }}>
-            <button onClick={dec} aria-label="Decrease" title="Decrease" style={{ width: 32, height: 32, borderRadius: 999, display: 'grid', placeItems: 'center' }}>–</button>
-            <div style={{ minWidth: 24, textAlign: 'center', fontWeight: 800 }}>{qty}</div>
-            <button onClick={inc} aria-label="Increase" title="Increase" style={{ width: 32, height: 32, borderRadius: 999, display: 'grid', placeItems: 'center' }}>+</button>
+            <button onClick={dec} aria-label="Decrease" title="Decrease" className="hover-float" style={{ width: 32, height: 32, borderRadius: 999, display: 'grid', placeItems: 'center' }}>–</button>
+            <div className={bump ? 'animate-bump' : ''} style={{ minWidth: 24, textAlign: 'center', fontWeight: 800 }}>{qty}</div>
+            <button onClick={inc} aria-label="Increase" title="Increase" className="hover-float" style={{ width: 32, height: 32, borderRadius: 999, display: 'grid', placeItems: 'center' }}>+</button>
           </div>
         </div>
 
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
-          <button onClick={onCancel} style={{ padding: '10px 14px', borderRadius: 10, border: '1px solid var(--border)', background: 'var(--panel-2)' }}>Cancel</button>
-          <button onClick={() => onConfirm(qty)} className="primary-btn" style={{ padding: '10px 16px', borderRadius: 10, minWidth: 140 }}>Add to cart</button>
+          <button onClick={onCancel} className="hover-float" style={{ padding: '10px 14px', borderRadius: 10, border: '1px solid var(--border)', background: 'var(--panel-2)' }}>Cancel</button>
+          <button onClick={() => onConfirm(qty)} className="primary-btn hover-float" style={{ padding: '10px 16px', borderRadius: 10, minWidth: 140 }}>Add to cart</button>
         </div>
       </div>
     </Modal>

--- a/shop/frontend/src/components/SpiceModal.jsx
+++ b/shop/frontend/src/components/SpiceModal.jsx
@@ -46,8 +46,8 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
         })}
       </div>
       <div style={{ display: 'flex', justifyContent: 'center', gap: 12, marginTop: 16 }}>
-        <button onClick={onCancel} style={{ padding: '12px 16px', borderRadius: 12, border: '1px solid var(--border)', background: 'var(--panel-2)' }}>Cancel</button>
-        <button onClick={() => onConfirm(selected)} className="primary-btn" style={{ padding: '12px 16px', borderRadius: 12, minWidth: 140 }}>OK</button>
+        <button onClick={onCancel} className="hover-float" style={{ padding: '12px 16px', borderRadius: 12, border: '1px solid var(--border)', background: 'var(--panel-2)' }}>Cancel</button>
+        <button onClick={() => onConfirm(selected)} className="primary-btn hover-float" style={{ padding: '12px 16px', borderRadius: 12, minWidth: 140 }}>OK</button>
       </div>
     </Modal>
   );

--- a/shop/frontend/src/index.css
+++ b/shop/frontend/src/index.css
@@ -165,6 +165,14 @@ input:focus, select:focus, textarea:focus {
 .animate-slideInLeft { animation: slideInLeft .25s ease-out both; }
 .animate-slideInRight { animation: slideInRight .25s ease-out both; }
 
+/* Micro animations */
+@keyframes bump {
+  0% { transform: scale(1); }
+  35% { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+.animate-bump { animation: bump .18s cubic-bezier(.22,.7,.3,1) both; }
+
 /* Tiny utility for subtle floating hover */
 .hover-float:hover { transform: translateY(-2px); box-shadow: var(--shadow-pop); }
 


### PR DESCRIPTION
Add micro-animations to Quick Add modal buttons and quantity stepper, show an options summary in the add-to-cart toast, and fix a 403 Forbidden error for takeout orders.

The 403 Forbidden error occurred because the backend `requireUser` middleware for pickup orders only permitted 'user' roles, preventing 'admin' users from completing takeout selections. This has been updated to allow both 'user' and 'admin' roles.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a53dfe2-c6e3-4e84-b32a-5aba6bb6e81a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a53dfe2-c6e3-4e84-b32a-5aba6bb6e81a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

