### PR TITLE
Update image assets for models

### DIFF
--- a/shop/frontend/src/components/FulfillmentModal.jsx
+++ b/shop/frontend/src/components/FulfillmentModal.jsx
@@ -6,12 +6,12 @@ export const FulfillmentModal = ({ open, onChoose }) => {
   const pickupImg = getPickupImage();
   const deliveryImg = getDeliveryImage();
   return (
-    <Modal open={open} onClose={() => {}} title="Choose your order type">
+    <Modal open={open} onClose={() => {}} title={null}>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
         <button
           onClick={() => onChoose('pickup')}
           style={{
-            padding: 0,
+            padding: 10,
             borderRadius: 16,
             overflow: 'hidden',
             border: '1px solid var(--border)',
@@ -19,22 +19,20 @@ export const FulfillmentModal = ({ open, onChoose }) => {
           }}
           className="animate-fadeInUp"
         >
-          <div style={{ padding: 14, display: 'grid', gap: 6, textAlign: 'center' }}>
+          <div style={{ padding: 12, display: 'grid', gap: 6, textAlign: 'center' }}>
             {pickupImg ? (
-              <div style={{ height: 90, display: 'grid', placeItems: 'center' }}>
-                <img src={pickupImg} alt="Pickup" style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }} />
+              <div style={{ height: 120, display: 'grid', placeItems: 'center' }}>
+                <img src={pickupImg} alt="Pickup" loading="eager" decoding="async" style={{ maxWidth: '85%', maxHeight: '85%', objectFit: 'contain', filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.12))' }} />
               </div>
             ) : (
               <div style={{ fontSize: 32 }}>🏪</div>
             )}
-            <div style={{ fontWeight: 800 }}>Pickup</div>
-            <div className="muted" style={{ fontSize: 12 }}>Choose by location or city</div>
           </div>
         </button>
         <button
           onClick={() => onChoose('delivery')}
           style={{
-            padding: 0,
+            padding: 10,
             borderRadius: 16,
             overflow: 'hidden',
             border: '1px solid var(--primary-600)',
@@ -42,16 +40,14 @@ export const FulfillmentModal = ({ open, onChoose }) => {
           }}
           className="animate-fadeInUp"
         >
-          <div style={{ padding: 14, display: 'grid', gap: 6, textAlign: 'center' }}>
+          <div style={{ padding: 12, display: 'grid', gap: 6, textAlign: 'center' }}>
             {deliveryImg ? (
-              <div style={{ height: 90, display: 'grid', placeItems: 'center' }}>
-                <img src={deliveryImg} alt="Delivery" style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }} />
+              <div style={{ height: 120, display: 'grid', placeItems: 'center' }}>
+                <img src={deliveryImg} alt="Delivery" loading="eager" decoding="async" style={{ maxWidth: '85%', maxHeight: '85%', objectFit: 'contain', filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.12))' }} />
               </div>
             ) : (
               <div style={{ fontSize: 32 }}>🚚</div>
             )}
-            <div style={{ fontWeight: 800 }}>Delivery</div>
-            <div className="muted" style={{ fontSize: 12 }}>Enter your address</div>
           </div>
         </button>
       </div>

--- a/shop/frontend/src/components/SpiceModal.jsx
+++ b/shop/frontend/src/components/SpiceModal.jsx
@@ -1,9 +1,6 @@
 import React, { useState } from 'react';
 import { Modal } from './Modal';
-import chilliGreen from '../assets/chilli-green.svg';
-import chilliOrange from '../assets/chilli-orange.svg';
-import chilliRed from '../assets/chilli-red.svg';
-import { getSpiceBadge } from '../lib/assetFinder';
+import { getSpiceBadge, findAssetByKeywords } from '../lib/assetFinder';
 
 export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) => {
   const [selected, setSelected] = useState(undefined);
@@ -25,47 +22,47 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
           </div>
         </div>
       ) : null}
-      <div style={{ fontWeight: 800, marginBottom: 6 }}>Choose spice level</div>
+      {/* Label removed per request: show images only */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
         {levels.map((lvl) => {
           const lower = String(lvl || '').toLowerCase();
-          const badge = getSpiceBadge(lvl);
-          const fallback = lower.includes('hot')
-            ? chilliRed
-            : (lower.includes('medium') || lower.includes('spicy'))
-              ? chilliOrange
-              : chilliGreen;
-          const imgSrc = badge || fallback;
+          const imgSrc = getSpiceBadge(lvl) || findAssetByKeywords(['extra-hot', 'hot', 'medium', 'mild', 'spice', 'chilli', 'pepper']);
           const active = selected === lvl;
           return (
             <button
               key={lvl}
               onClick={() => setSelected(lvl)}
+              aria-label={lvl}
               style={{
-                padding: '12px 16px',
-                borderRadius: 999,
+                padding: 10,
+                borderRadius: 16,
                 border: active ? '2px solid var(--primary-600)' : '1px solid var(--border)',
                 background: active ? 'var(--primary-alpha-12)' : 'var(--panel-2)',
                 cursor: 'pointer',
-                display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, minWidth: 140
+                display: 'grid', placeItems: 'center'
               }}
             >
               <div style={{
-                width: 180,
-                height: 60,
+                width: 120,
+                height: 120,
                 display: 'grid',
                 placeItems: 'center',
                 background: 'linear-gradient(180deg, rgba(255,255,255,0.85), rgba(255,255,255,0.70))',
                 borderRadius: 14,
                 border: '1px solid var(--border)'
               }}>
-                <img
-                  src={imgSrc}
-                  alt={`${lvl} level`}
-                  style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.15))' }}
-                />
+                {imgSrc ? (
+                  <img
+                    src={imgSrc}
+                    alt={`${lvl} spice`}
+                    loading="eager"
+                    decoding="async"
+                    style={{ maxWidth: '80%', maxHeight: '80%', objectFit: 'contain', filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.12))' }}
+                  />
+                ) : (
+                  <div style={{ fontSize: 42 }}>🌶️</div>
+                )}
               </div>
-              <div style={{ fontWeight: 700 }}>{lvl}</div>
             </button>
           );
         })}

--- a/shop/frontend/src/components/SpiceModal.jsx
+++ b/shop/frontend/src/components/SpiceModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Modal } from './Modal';
-import { getSpiceBadge, findAssetByKeywords } from '../lib/assetFinder';
+import { getSpiceBadge, findAssetByKeywords, normalizeSpiceLevel } from '../lib/assetFinder';
 
 export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) => {
   const [selected, setSelected] = useState(undefined);
@@ -23,41 +23,26 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
         </div>
       ) : null}
       {/* Label removed per request: show images only */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
+      <div className="image-choice-grid">
         {levels.map((lvl) => {
-          const lower = String(lvl || '').toLowerCase();
-          const imgSrc = getSpiceBadge(lvl) || findAssetByKeywords(['extra-hot', 'hot', 'medium', 'mild', 'spice', 'chilli', 'pepper']);
-          const active = selected === lvl;
+          const canonical = normalizeSpiceLevel(lvl);
+          const imgSrc = getSpiceBadge(canonical) || findAssetByKeywords([canonical, 'spice', 'chilli', 'pepper']);
+          const active = normalizeSpiceLevel(selected) === canonical;
           return (
             <button
               key={lvl}
-              onClick={() => setSelected(lvl)}
-              aria-label={lvl}
-              style={{
-                padding: 10,
-                borderRadius: 16,
-                border: active ? '2px solid var(--primary-600)' : '1px solid var(--border)',
-                background: active ? 'var(--primary-alpha-12)' : 'var(--panel-2)',
-                cursor: 'pointer',
-                display: 'grid', placeItems: 'center'
-              }}
+              onClick={() => setSelected(canonical)}
+              aria-label={canonical}
+              className="image-choice"
+              data-active={active}
             >
-              <div style={{
-                width: 120,
-                height: 120,
-                display: 'grid',
-                placeItems: 'center',
-                background: 'linear-gradient(180deg, rgba(255,255,255,0.85), rgba(255,255,255,0.70))',
-                borderRadius: 14,
-                border: '1px solid var(--border)'
-              }}>
+              <div className="image-square">
                 {imgSrc ? (
                   <img
                     src={imgSrc}
-                    alt={`${lvl} spice`}
+                    alt={`${canonical} spice`}
                     loading="eager"
                     decoding="async"
-                    style={{ maxWidth: '80%', maxHeight: '80%', objectFit: 'contain', filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.12))' }}
                   />
                 ) : (
                   <div style={{ fontSize: 42 }}>🌶️</div>

--- a/shop/frontend/src/index.css
+++ b/shop/frontend/src/index.css
@@ -188,6 +188,24 @@ input:focus, select:focus, textarea:focus {
   display: block;
 }
 
+/* Image-only button grid helpers for popups */
+.image-choice-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+.image-choice {
+  padding: 10px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+}
+.image-choice[data-active="true"] {
+  border: 2px solid var(--primary-600);
+  background: var(--primary-alpha-12);
+}
+
 /* Layout helpers */
 .content {
   margin-right: 380px; /* space for cart */

--- a/shop/frontend/src/index.css
+++ b/shop/frontend/src/index.css
@@ -206,6 +206,23 @@ input:focus, select:focus, textarea:focus {
   background: var(--primary-alpha-12);
 }
 
+/* Square image container with nice gradient background */
+.image-square {
+  width: 120px;
+  height: 120px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(180deg, rgba(255,255,255,0.85), rgba(255,255,255,0.70));
+  border-radius: 14px;
+  border: 1px solid var(--border);
+}
+.image-square img {
+  max-width: 80%;
+  max-height: 80%;
+  object-fit: contain;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.12));
+}
+
 /* Layout helpers */
 .content {
   margin-right: 380px; /* space for cart */

--- a/shop/frontend/src/lib/assetFinder.js
+++ b/shop/frontend/src/lib/assetFinder.js
@@ -45,14 +45,14 @@ export function findAssetByKeywords(keywords) {
  */
 export function getPickupImage() {
   return (
-    findAssetByKeywords(['pickup', 'store', 'shop', 'takeout', 'image1', 'img1']) ||
+    findAssetByKeywords(['pickup', 'pick-up', 'counter', 'store', 'shop', 'takeout', 'carryout', 'collection', 'takeaway', 'take-away']) ||
     undefined
   );
 }
 
 export function getDeliveryImage() {
   return (
-    findAssetByKeywords(['delivery', 'truck', 'van', 'courier', 'image2', 'img2']) ||
+    findAssetByKeywords(['delivery', 'deliver', 'courier', 'rider', 'driver', 'bike', 'scooter', 'truck', 'van']) ||
     undefined
   );
 }
@@ -60,12 +60,14 @@ export function getDeliveryImage() {
 export function getSpiceBadge(level) {
   const lower = String(level || '').toLowerCase();
   if (lower.includes('extra'))
-    return findAssetByKeywords(['extra', 'level4', 'lvl4', '4']);
+    return findAssetByKeywords(['extra-hot', 'extra_hot', 'xhot', 'x-hot', 'very-hot', 'veryhot', 'extra', 'level4', 'lvl4', '4', 'spice']);
   if (lower.includes('hot'))
-    return findAssetByKeywords(['hot', 'level3', 'lvl3', '3']);
+    return findAssetByKeywords(['hot', 'level3', 'lvl3', '3', 'spice']);
   if (lower.includes('medium') || lower.includes('spicy'))
-    return findAssetByKeywords(['spicy', 'medium', 'level2', 'lvl2', '2']);
-  // default/mild
-  return findAssetByKeywords(['mild', 'level1', 'lvl1', '1']);
+    return findAssetByKeywords(['medium', 'spicy', 'level2', 'lvl2', '2', 'spice']);
+  if (lower.includes('mild') || lower.includes('low'))
+    return findAssetByKeywords(['mild', 'low', 'level1', 'lvl1', '1', 'spice']);
+  // generic fallback if no match
+  return findAssetByKeywords(['spice', 'chilli', 'chili', 'pepper']);
 }
 


### PR DESCRIPTION
Remove text labels and update `SpiceModal` and `FulfillmentModal` to display only images for spice levels and order types, improving visual quality and alignment, and enhancing asset lookup for renamed images.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7493cef-2b47-4185-a4bd-d86187c3dcd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7493cef-2b47-4185-a4bd-d86187c3dcd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

