### PR TITLE
Enhance order details and add coupon feature

### DIFF
--- a/shop/frontend/src/components/FulfillmentModal.jsx
+++ b/shop/frontend/src/components/FulfillmentModal.jsx
@@ -20,6 +20,7 @@ export const FulfillmentModal = ({ open, onChoose }) => {
           className="animate-fadeInUp"
         >
           <div style={{ padding: 12, display: 'grid', gap: 6, textAlign: 'center' }}>
+            <div style={{ fontWeight: 800 }}>Pickup</div>
             {pickupImg ? (
               <div style={{ height: 120, display: 'grid', placeItems: 'center' }}>
                 <img src={pickupImg} alt="Pickup" loading="eager" decoding="async" style={{ maxWidth: '85%', maxHeight: '85%', objectFit: 'contain', filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.12))' }} />
@@ -27,7 +28,6 @@ export const FulfillmentModal = ({ open, onChoose }) => {
             ) : (
               <div style={{ fontSize: 32 }}>🏪</div>
             )}
-            <div style={{ fontWeight: 700 }}>Pickup</div>
           </div>
         </button>
         <button
@@ -42,6 +42,7 @@ export const FulfillmentModal = ({ open, onChoose }) => {
           className="animate-fadeInUp"
         >
           <div style={{ padding: 12, display: 'grid', gap: 6, textAlign: 'center' }}>
+            <div style={{ fontWeight: 800 }}>Delivery</div>
             {deliveryImg ? (
               <div style={{ height: 120, display: 'grid', placeItems: 'center' }}>
                 <img src={deliveryImg} alt="Delivery" loading="eager" decoding="async" style={{ maxWidth: '85%', maxHeight: '85%', objectFit: 'contain', filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.12))' }} />
@@ -49,7 +50,6 @@ export const FulfillmentModal = ({ open, onChoose }) => {
             ) : (
               <div style={{ fontSize: 32 }}>🚚</div>
             )}
-            <div style={{ fontWeight: 700 }}>Delivery</div>
           </div>
         </button>
       </div>

--- a/shop/frontend/src/components/SpiceModal.jsx
+++ b/shop/frontend/src/components/SpiceModal.jsx
@@ -4,7 +4,8 @@ import { getSpiceBadge, findAssetByKeywords, normalizeSpiceLevel } from '../lib/
 
 export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) => {
   const [selected, setSelected] = useState(undefined);
-  const levels = spiceLevels && spiceLevels.length > 0 ? spiceLevels : ['Mild', 'Medium', 'Hot'];
+  const baseDefaults = ['Mild', 'Medium', 'Hot'];
+  const levels = Array.from(new Set((Array.isArray(spiceLevels) && spiceLevels.length > 0) ? [...spiceLevels, ...baseDefaults] : baseDefaults));
 
   return (
     <Modal open={open} onClose={onCancel} title={null}>
@@ -22,7 +23,6 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
           </div>
         </div>
       ) : null}
-      {/* Label removed per request: show images only */}
       <div className="image-choice-grid">
         {levels.map((lvl) => {
           const canonical = normalizeSpiceLevel(lvl);
@@ -48,6 +48,7 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
                   <div style={{ fontSize: 42 }}>🌶️</div>
                 )}
               </div>
+              <div style={{ marginTop: 6, fontWeight: 700, textTransform: 'capitalize' }}>{canonical.replace('-', ' ')}</div>
             </button>
           );
         })}

--- a/shop/frontend/src/index.css
+++ b/shop/frontend/src/index.css
@@ -208,8 +208,8 @@ input:focus, select:focus, textarea:focus {
 
 /* Square image container with nice gradient background */
 .image-square {
-  width: 120px;
-  height: 120px;
+  width: 160px;
+  height: 160px;
   display: grid;
   place-items: center;
   background: linear-gradient(180deg, rgba(255,255,255,0.85), rgba(255,255,255,0.70));
@@ -217,8 +217,8 @@ input:focus, select:focus, textarea:focus {
   border: 1px solid var(--border);
 }
 .image-square img {
-  max-width: 80%;
-  max-height: 80%;
+  max-width: 90%;
+  max-height: 90%;
   object-fit: contain;
   filter: drop-shadow(0 1px 2px rgba(0,0,0,0.12));
 }


### PR DESCRIPTION
Improve spice level visibility and reposition pickup/delivery labels.

Ensured 'Mild' and 'Hot' spice levels are always available, increased the size of spice level images, and added text labels below them for clarity. The "Pickup" and "Delivery" labels were moved to the top of their respective cards in the fulfillment modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-46c9b8cb-2c03-475a-aa49-1efb18effc6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46c9b8cb-2c03-475a-aa49-1efb18effc6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

