### PR TITLE
Fix cart display and date format on small screens

### DIFF
--- a/shop/frontend/src/ShopApp.js
+++ b/shop/frontend/src/ShopApp.js
@@ -341,9 +341,9 @@ const Main = ({ siteSlug = 'default', initialCategoryId }) => {
         {content}
       </main>
 
-      <button className="cart-fab hide-desktop" onClick={() => setMobileCartOpen(true)}>
-        <span style={{ fontSize: 18 }}>🛒</span>
-        <span style={{ fontWeight: 800 }}>Cart ({state.items.length})</span>
+      <button className="cart-fab hide-desktop" aria-label="Open cart" onClick={() => setMobileCartOpen(true)}>
+        <span className="cart-fab__icon">🛒</span>
+        {state.items.length > 0 ? <span className="cart-fab__badge" aria-label={`Items in cart: ${state.items.length}`}>{state.items.length}</span> : null}
       </button>
 
       <PrivacyPolicyModal open={privacyOpen} onAccept={handleAcceptPrivacy} />

--- a/shop/frontend/src/components/CartSidebar.jsx
+++ b/shop/frontend/src/components/CartSidebar.jsx
@@ -37,7 +37,7 @@ export const CartSidebar = ({ open, onClose, onCheckout, readyAt }) => {
       className="animate-slideInRight cart-sidebar"
       data-open={open ? 'true' : 'false'}
     >
-      <div className="card" style={{ padding: 14, borderRadius: 12, marginBottom: 12, borderTop: '3px solid var(--primary)' }}>
+      <div className="card cart-header" style={{ padding: 14, borderRadius: 12, marginBottom: 12, borderTop: '3px solid var(--primary)', position: 'sticky', top: 0, background: '#fff', zIndex: 1 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div>
             <div style={{ fontSize: 12 }} className="muted">ORDER READY FOR</div>

--- a/shop/frontend/src/components/OrderDetailsBar.jsx
+++ b/shop/frontend/src/components/OrderDetailsBar.jsx
@@ -80,12 +80,7 @@ export const OrderDetailsBar = ({
                 ))}
               </select>
             </label>
-            {/* Show selected date alongside time for clarity (visible box) */}
-            {selectedDateLabel ? (
-              <div aria-label="Selected date" className="order-bar__input" style={{ display: 'flex', alignItems: 'center', fontWeight: 600 }}>
-                {selectedDateLabel}
-              </div>
-            ) : null}
+            {/* Removed duplicate selected date display to avoid showing date twice */}
           </div>
         </div>
       </div>

--- a/shop/frontend/src/index.css
+++ b/shop/frontend/src/index.css
@@ -282,15 +282,35 @@ input:focus, select:focus, textarea:focus {
   bottom: 16px;
   display: none;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  gap: 0;
   border-radius: 9999px;
-  padding: 10px 14px;
+  width: 52px;
+  height: 52px;
   box-shadow: var(--shadow-pop);
   background: linear-gradient(180deg, var(--primary-alpha-25), var(--primary-alpha-12));
   border: 1px solid var(--primary-600);
 }
 @media (max-width: 1024px) {
   .cart-fab { display: inline-flex; }
+}
+
+/* Cart FAB internals */
+.cart-fab__icon { font-size: 22px; line-height: 1; }
+.cart-fab__badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 9999px;
+  background: #000;
+  color: #fff;
+  font-size: 12px;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.25);
 }
 
 /* Visibility helpers */


### PR DESCRIPTION
Display only one day and date, and refactor the mobile cart to a floating icon that opens a sidebar with a close button.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb1712fb-8ee1-4747-9206-85a928281726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb1712fb-8ee1-4747-9206-85a928281726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

