### PR TITLE
Implement spicy level options and clean images

### DIFF
--- a/shop/frontend/src/components/SpiceModal.jsx
+++ b/shop/frontend/src/components/SpiceModal.jsx
@@ -9,8 +9,9 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
   const levels = useMemo(() => {
     const input = Array.isArray(spiceLevels) && spiceLevels.length > 0 ? spiceLevels : baseDefaults;
     const canonicalSet = new Set(input.map((lvl) => normalizeSpiceLevel(lvl)));
-    // Ensure common order and include any custom levels at the end
+    // Ensure we ALWAYS show the four standard levels regardless of backend config
     const ordered = ['mild', 'medium', 'hot', 'extra-hot'];
+    for (const std of ordered) canonicalSet.add(std);
     const result = [];
     for (const key of ordered) {
       if (canonicalSet.has(key)) result.push(key);
@@ -18,7 +19,7 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
     for (const key of canonicalSet) {
       if (!ordered.includes(key)) result.push(key);
     }
-    return result.length ? result : ordered;
+    return result;
   }, [spiceLevels]);
 
   return (
@@ -61,7 +62,6 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
                   <div style={{ fontSize: 42 }}>🌶️</div>
                 )}
               </div>
-              <div style={{ marginTop: 6, fontWeight: 700, textTransform: 'capitalize' }}>{canonical.replace('-', ' ')}</div>
             </button>
           );
         })}

--- a/shop/frontend/src/index.css
+++ b/shop/frontend/src/index.css
@@ -196,14 +196,14 @@ input:focus, select:focus, textarea:focus {
   justify-content: center;
 }
 .image-choice {
-  padding: 10px;
+  padding: 0;
   border-radius: 16px;
-  border: 1px solid var(--border);
-  background: var(--panel-2);
+  border: none;
+  background: transparent;
 }
 .image-choice[data-active="true"] {
-  border: 2px solid var(--primary-600);
-  background: var(--primary-alpha-12);
+  outline: 3px solid var(--primary-600);
+  outline-offset: 4px;
 }
 
 /* Square image container with nice gradient background */
@@ -212,9 +212,9 @@ input:focus, select:focus, textarea:focus {
   height: 160px;
   display: grid;
   place-items: center;
-  background: linear-gradient(180deg, rgba(255,255,255,0.85), rgba(255,255,255,0.70));
+  background: transparent;
   border-radius: 14px;
-  border: 1px solid var(--border);
+  border: none;
 }
 .image-square img {
   max-width: 90%;

--- a/shop/frontend/src/lib/assetFinder.js
+++ b/shop/frontend/src/lib/assetFinder.js
@@ -161,25 +161,42 @@ export function getDeliveryImage() {
 
 export function getSpiceBadge(level) {
   const canonical = normalizeSpiceLevel(level);
-  if (canonical === 'extra-hot')
+  function tryExactBaseNames(bases) {
+    for (const base of bases) {
+      for (const ext of ['.png', '.svg', '.jpg', '.jpeg', '.webp', '.gif']) {
+        const hit = filenameToUrl.get(`${base}${ext}`);
+        if (hit) return hit;
+      }
+    }
+    return undefined;
+  }
+
+  if (canonical === 'extra-hot') {
     return (
-      filenameToUrl.get('extra hot.png') || filenameToUrl.get('extra-hot.png') || filenameToUrl.get('extra_hot.png') ||
-      findAssetByKeywords(['extra-hot', 'extra hot', 'extra_hot', 'xhot', 'x-hot', 'very-hot', 'veryhot', 'extra', 'level4', 'lvl4', '4', 'spice'])
+      // Prefer explicit "extra" assets
+      tryExactBaseNames(['extra hot', 'extra-hot', 'extra_hot', 'chilli-extra', 'chili-extra', 'xhot', 'x-hot', 'xxhot', 'xx-hot']) ||
+      // Otherwise fall back to keywords
+      findAssetByKeywords(['extra-hot', 'extra hot', 'extra_hot', 'very-hot', 'veryhot', 'xhot', 'x-hot', 'extra', 'level4', 'lvl4', '4', 'spice', 'chilli-red', 'chili-red', 'red']) ||
+      // Final fallback to red chilli if present
+      tryExactBaseNames(['chilli-red', 'chili-red'])
     );
-  if (canonical === 'hot')
+  }
+  if (canonical === 'hot') {
     return (
-      filenameToUrl.get('hot.png') ||
-      findAssetByKeywords(['hot', 'spicy', 'level3', 'lvl3', '3', 'spice'])
+      tryExactBaseNames(['hot', 'chilli-red', 'chili-red']) ||
+      findAssetByKeywords(['hot', 'spicy', 'level3', 'lvl3', '3', 'spice', 'red', 'chilli', 'pepper'])
     );
-  if (canonical === 'medium')
+  }
+  if (canonical === 'medium') {
     return (
-      filenameToUrl.get('medium.png') ||
-      findAssetByKeywords(['medium', 'moderate', 'level2', 'lvl2', '2', 'spice'])
+      tryExactBaseNames(['medium', 'chilli-orange', 'chili-orange']) ||
+      findAssetByKeywords(['medium', 'moderate', 'level2', 'lvl2', '2', 'spice', 'orange'])
     );
+  }
   // default/mild
   return (
-    filenameToUrl.get('mild.png') ||
-    findAssetByKeywords(['mild', 'low', 'level1', 'lvl1', '1', 'spice'])
+    tryExactBaseNames(['mild', 'chilli-green', 'chili-green']) ||
+    findAssetByKeywords(['mild', 'low', 'level1', 'lvl1', '1', 'spice', 'green'])
   );
 }
 


### PR DESCRIPTION
Display all four spice levels in the UI with image-only selection and improved asset mapping.

The spice level modal now consistently shows Mild, Medium, Hot, and Extra Hot options, overriding backend configurations to ensure all four are always present. UI elements like card backgrounds and text labels have been removed to present a cleaner, image-only selection. Asset mapping has been extended to better recognize user-provided image filenames for each spice level.

---
<a href="https://cursor.com/background-agent?bcId=bc-014c0b81-be6f-440c-a681-b99b1f02ac53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-014c0b81-be6f-440c-a681-b99b1f02ac53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

