### PR TITLE
Fix address selection, distance, and delivery fee

### DIFF
--- a/shop/frontend/src/components/OrderDetailsBar.jsx
+++ b/shop/frontend/src/components/OrderDetailsBar.jsx
@@ -93,10 +93,13 @@ export const OrderDetailsBar = ({
           <select
             className="order-bar__input"
             aria-label="Select restaurant address"
-            value={String(typeof selectedLocationIndex === 'number' ? selectedLocationIndex : 0)}
+            value={(typeof selectedLocationIndex === 'number' && selectedLocationIndex >= 0) ? String(selectedLocationIndex) : ''}
             onChange={(e) => onChangeLocation && onChangeLocation(Number(e.target.value))}
             style={{ padding: '6px 10px', borderRadius: 8 }}
           >
+            {(typeof selectedLocationIndex !== 'number' || selectedLocationIndex < 0) ? (
+              <option value="" disabled>Select a location</option>
+            ) : null}
             {locations.map((loc, idx) => {
               const text = `${loc?.name || 'Restaurant'} — ${(loc?.address?.streetAddress || []).join(' ')}, ${loc?.address?.city || ''}`;
               return (


### PR DESCRIPTION
Implement persistent restaurant address selection and improve geocoding for accurate distance-based delivery fees.

Fixes issues where the first restaurant was always selected, and delivery fees were a flat $8 due to failed distance calculations. The changes ensure the chosen restaurant address is remembered and geocoding can parse messy province/postal inputs with fallbacks to correctly calculate distance.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a0567f7-a23d-405b-b9bc-7d9752ceaf7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a0567f7-a23d-405b-b9bc-7d9752ceaf7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

