### PR TITLE
Fix mobile cart display issue

### DIFF
--- a/shop/frontend/src/components/CartSidebar.jsx
+++ b/shop/frontend/src/components/CartSidebar.jsx
@@ -36,7 +36,7 @@ export const CartSidebar = ({ open, onClose, onCheckout, readyAt }) => {
         // Ensure desktop cart sits above any fixed bars (header/footer)
         zIndex: 120,
       }}
-      className="animate-slideInRight cart-sidebar"
+      className="cart-sidebar"
       data-open={open ? 'true' : 'false'}
     >
       <div className="card cart-header" style={{ padding: 14, borderRadius: 12, marginBottom: 12, borderTop: '3px solid var(--primary)', position: 'sticky', top: 0, background: '#fff', zIndex: 1 }}>


### PR DESCRIPTION
Remove `animate-slideInRight` from `CartSidebar` to fix the mobile cart not closing.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ced636a-5870-4429-8da0-fd60448f9193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ced636a-5870-4429-8da0-fd60448f9193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

