### PR TITLE
Admin panel delivery fee split and order details update

### DIFF
--- a/shop/backend/src/models/Order.js
+++ b/shop/backend/src/models/Order.js
@@ -22,6 +22,8 @@ const OrderSchema = new mongoose.Schema({
     // Tip removed from system; keep field for backward compatibility set to 0
     tipCents: { type: Number, default: 0, select: true },
     deliveryFeeCents: { type: Number, default: 0 },
+    // When splitDeliveryFee is enabled on Site, this stores restaurant's half
+    deliveryFeeRestaurantCents: { type: Number, default: 0 },
     // Freeform notes from customer to restaurant (e.g., extra spicy, no onions)
     notes: { type: String },
     externalId: { type: String },

--- a/shop/backend/src/models/Product.js
+++ b/shop/backend/src/models/Product.js
@@ -15,6 +15,12 @@ const ProductSchema = new mongoose.Schema({
 	categoryId: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
 	isVeg: { type: Boolean, default: true },
 	spiceLevels: [{ type: String }],
+	// Product variants (e.g., sizes). priceDelta is added on top of base price
+	variants: [{
+		key: { type: String, required: true },
+		label: { type: String, required: true },
+		priceDelta: { type: Number, default: 0 },
+	}],
 	extraOptionGroups: [{
 		groupKey: { type: String, required: true },
 		groupLabel: { type: String, required: true },

--- a/shop/backend/src/models/Site.js
+++ b/shop/backend/src/models/Site.js
@@ -11,6 +11,8 @@ const SiteSchema = new mongoose.Schema({
 	uberCustomerId: { type: String },
 	// Flat delivery fee in cents applied to delivery orders only
 	deliveryFeeCents: { type: Number, default: 0 },
+	// When true, split delivery fee 50/50 between customer and restaurant
+	splitDeliveryFee: { type: Boolean, default: false },
 	// New: support multiple pickup locations for a site while keeping legacy `pickup`
 	locations: [{
 		name: { type: String },

--- a/shop/backend/src/routes/adminOrders.js
+++ b/shop/backend/src/routes/adminOrders.js
@@ -191,6 +191,7 @@ router.get('/:orderId/pdf', requireAdmin, async (req, res) => {
 			doc.addPage();
 		}
     const delivery = Number(order.deliveryFeeCents || 0) / 100;
+    const deliveryRestaurant = Number(order.deliveryFeeRestaurantCents || 0) / 100;
     const tax = Number(order.taxCents || 0) / 100;
     const tip = Number(order.tipCents || 0) / 100;
     const grandTotal = Number(order.totalCents || 0) / 100;
@@ -202,7 +203,7 @@ router.get('/:orderId/pdf', requireAdmin, async (req, res) => {
 		doc.save();
 		doc.roundedRect(startX, doc.y - 4, tableWidth, 80, 6).strokeColor(colors.border).stroke();
 		doc.restore();
-		function row(label, value) {
+    function row(label, value) {
       const y = doc.y;
 			doc.font('Helvetica').fillColor(colors.textDark).text(label, valueX - labelWidth, y, { width: labelWidth, align: 'right' });
 			doc.text(`$${(Number(value)||0).toFixed(2)}`, valueX, y, { width: 100, align: 'right' });
@@ -216,7 +217,14 @@ router.get('/:orderId/pdf', requireAdmin, async (req, res) => {
     const taxRatePct = itemsSubtotal > 0 ? Math.round((tax / itemsSubtotal) * 1000) / 10 : null;
     row(`Tax${taxRatePct !== null ? ` (${taxRatePct}% )` : ''}`, tax);
     if (tip > 0) row('Tip', tip);
-    if (delivery > 0) row('Delivery Fee', delivery);
+    if (delivery > 0) {
+      if (deliveryRestaurant > 0) {
+        row('Delivery by restaurant', deliveryRestaurant);
+        row('Delivery fee (customer)', delivery);
+      } else {
+        row('Delivery Fee', delivery);
+      }
+    }
     doc.moveDown(0.2);
 		doc.moveTo(startX, doc.y).lineTo(startX + tableWidth, doc.y).strokeColor(colors.border).stroke();
     doc.moveDown(0.2);

--- a/shop/backend/src/routes/adminProducts.js
+++ b/shop/backend/src/routes/adminProducts.js
@@ -52,7 +52,7 @@ router.post('/', requireAdmin, async (req, res) => {
 		const { siteId } = req.params;
 		const mock = req.app.locals.mockData;
 		if (mock) {
-			const payload = { ...req.body, site: siteId };
+    const payload = { ...req.body, site: siteId };
 			const catOk = mock.categories.some((c) => c._id === payload.categoryId && c.site === siteId);
 			if (!catOk) return res.status(400).json({ error: 'Invalid category for site' });
 			const created = { _id: `p-${Date.now()}`, ...payload };
@@ -75,7 +75,7 @@ router.put('/:id', requireAdmin, async (req, res) => {
 		const { siteId, id } = req.params;
 		const mock = req.app.locals.mockData;
 		if (mock) {
-			const update = { ...req.body };
+    const update = { ...req.body };
 			if (update.categoryId) {
 				const ok = mock.categories.some((c) => c._id === update.categoryId && c.site === siteId);
 				if (!ok) return res.status(400).json({ error: 'Invalid category for site' });

--- a/shop/backend/src/routes/adminSites.js
+++ b/shop/backend/src/routes/adminSites.js
@@ -26,16 +26,16 @@ router.get('/', requireAdmin, async (_req, res) => {
 
 router.post('/', requireAdmin, async (req, res) => {
 	try {
-    const { name, slug, domains, uberCustomerId, pickup, brandColor, locations, cities, hours, deliveryFeeCents, logoUrl } = req.body || {};
+		const { name, slug, domains, uberCustomerId, pickup, brandColor, locations, cities, hours, deliveryFeeCents, splitDeliveryFee, logoUrl } = req.body || {};
 		if (!name || !slug) return res.status(400).json({ error: 'name and slug are required' });
 		const mock = req.app.locals.mockData;
     if (mock) {
-      const created = { _id: `site-${Date.now()}`, name, slug, domains: domains || [], uberCustomerId, pickup, locations: Array.isArray(locations) ? locations : [], cities: Array.isArray(cities) ? cities : [], hours: hours || undefined, deliveryFeeCents: Number(deliveryFeeCents) || 0, brandColor: brandColor || '#0ea5e9', logoUrl, isActive: true };
+			const created = { _id: `site-${Date.now()}`, name, slug, domains: domains || [], uberCustomerId, pickup, locations: Array.isArray(locations) ? locations : [], cities: Array.isArray(cities) ? cities : [], hours: hours || undefined, deliveryFeeCents: Number(deliveryFeeCents) || 0, splitDeliveryFee: !!splitDeliveryFee, brandColor: brandColor || '#0ea5e9', logoUrl, isActive: true };
 			mock.sites.unshift(created);
 			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.status(201).json(created);
 		}
-    const site = await Site.create({ name, slug, domains: domains || [], uberCustomerId, pickup, locations: Array.isArray(locations) ? locations : [], cities: Array.isArray(cities) ? cities : [], hours, deliveryFeeCents: Number(deliveryFeeCents) || 0, brandColor: brandColor || '#0ea5e9', logoUrl, isActive: true });
+		const site = await Site.create({ name, slug, domains: domains || [], uberCustomerId, pickup, locations: Array.isArray(locations) ? locations : [], cities: Array.isArray(cities) ? cities : [], hours, deliveryFeeCents: Number(deliveryFeeCents) || 0, splitDeliveryFee: !!splitDeliveryFee, brandColor: brandColor || '#0ea5e9', logoUrl, isActive: true });
 		res.status(201).json(site);
 	} catch (err) {
 		res.status(400).json({ error: err.message });
@@ -45,17 +45,17 @@ router.post('/', requireAdmin, async (req, res) => {
 router.patch('/:siteId', requireAdmin, async (req, res) => {
 	try {
 		const { siteId } = req.params;
-    const { name, slug, domains, isActive, uberCustomerId, pickup, brandColor, locations, cities, hours, deliveryFeeCents, logoUrl } = req.body || {};
+		const { name, slug, domains, isActive, uberCustomerId, pickup, brandColor, locations, cities, hours, deliveryFeeCents, splitDeliveryFee, logoUrl } = req.body || {};
 		const mock = req.app.locals.mockData;
 		if (mock) {
 			const idx = mock.sites.findIndex((s) => s._id === siteId);
 			if (idx === -1) return res.status(404).json({ error: 'Not found' });
-      const updated = { ...mock.sites[idx], ...(name !== undefined ? { name } : {}), ...(slug !== undefined ? { slug } : {}), ...(domains !== undefined ? { domains } : {}), ...(isActive !== undefined ? { isActive } : {}), ...(uberCustomerId !== undefined ? { uberCustomerId } : {}), ...(pickup !== undefined ? { pickup } : {}), ...(brandColor !== undefined ? { brandColor } : {}), ...(locations !== undefined ? { locations } : {}), ...(cities !== undefined ? { cities } : {}), ...(hours !== undefined ? { hours } : {}), ...(deliveryFeeCents !== undefined ? { deliveryFeeCents: Number(deliveryFeeCents) || 0 } : {}), ...(logoUrl !== undefined ? { logoUrl } : {}) };
+			const updated = { ...mock.sites[idx], ...(name !== undefined ? { name } : {}), ...(slug !== undefined ? { slug } : {}), ...(domains !== undefined ? { domains } : {}), ...(isActive !== undefined ? { isActive } : {}), ...(uberCustomerId !== undefined ? { uberCustomerId } : {}), ...(pickup !== undefined ? { pickup } : {}), ...(brandColor !== undefined ? { brandColor } : {}), ...(locations !== undefined ? { locations } : {}), ...(cities !== undefined ? { cities } : {}), ...(hours !== undefined ? { hours } : {}), ...(deliveryFeeCents !== undefined ? { deliveryFeeCents: Number(deliveryFeeCents) || 0 } : {}), ...(splitDeliveryFee !== undefined ? { splitDeliveryFee: !!splitDeliveryFee } : {}), ...(logoUrl !== undefined ? { logoUrl } : {}) };
 			mock.sites[idx] = updated;
 			try { saveMockData(req.app.locals.mockData); } catch {}
 			return res.json(updated);
 		}
-    const site = await Site.findByIdAndUpdate(siteId, { name, slug, domains, isActive, uberCustomerId, pickup, brandColor, locations, cities, hours, deliveryFeeCents: deliveryFeeCents !== undefined ? Number(deliveryFeeCents) || 0 : undefined, logoUrl }, { new: true });
+		const site = await Site.findByIdAndUpdate(siteId, { name, slug, domains, isActive, uberCustomerId, pickup, brandColor, locations, cities, hours, deliveryFeeCents: deliveryFeeCents !== undefined ? Number(deliveryFeeCents) || 0 : undefined, splitDeliveryFee: splitDeliveryFee !== undefined ? !!splitDeliveryFee : undefined, logoUrl }, { new: true });
 		if (!site) return res.status(404).json({ error: 'Not found' });
 		res.json(site);
 	} catch (err) {

--- a/shop/backend/src/routes/delivery.js
+++ b/shop/backend/src/routes/delivery.js
@@ -48,12 +48,14 @@ router.post('/:slug/quote', async (req, res) => {
 		let distanceKm = null;
 		try { distanceKm = await distanceBetweenAddressesKm(pickup.address, dropoff.address); } catch {}
 		const distanceFeeCents = calculateDistanceFeeCents(distanceKm);
-		const quote = await requestQuote({
+    const quote = await requestQuote({
 			customerId: site.uberCustomerId,
 			pickup,
 			dropoff,
 		});
-		res.json({ ...quote, distanceKm, distanceFeeCents, pickupLocationIndex: chosenIdx });
+    const split = !!site.splitDeliveryFee;
+    const customerDeliveryFeeCents = split ? Math.round((Number(distanceFeeCents) || 0) / 2) : (Number(distanceFeeCents) || 0);
+    res.json({ ...quote, distanceKm, distanceFeeCents, customerDeliveryFeeCents, pickupLocationIndex: chosenIdx });
 	} catch (err) {
 		res.status(400).json({ error: err.message });
 	}
@@ -101,7 +103,7 @@ router.post('/:slug/create', requireAuth, async (req, res) => {
 		let distanceKm = null;
 		try { distanceKm = await distanceBetweenAddressesKm(pickup.address, dropoff.address); } catch {}
 		const distanceFeeCents = calculateDistanceFeeCents(distanceKm);
-		const delivery = await createDelivery({
+    const delivery = await createDelivery({
 			customerId: site.uberCustomerId,
 			pickup: safePickup,
 			dropoff,
@@ -112,9 +114,12 @@ router.post('/:slug/create', requireAuth, async (req, res) => {
 		// Record order
     const itemsTotal = (manifestItems || []).reduce((sum, it) => sum + (Number(it.price) || 0) * (Number(it.quantity) || 1), 0);
 		if (itemsTotal < 5000) return res.status(400).json({ error: 'Minimum order is $50.00' });
-		const deliveryFeeCents = Number(distanceFeeCents) || 0;
+    const split = !!site.splitDeliveryFee;
+    const fullDeliveryFeeCents = Number(distanceFeeCents) || 0;
+    const customerDeliveryFeeCents = split ? Math.round(fullDeliveryFeeCents / 2) : fullDeliveryFeeCents;
+    const restaurantDeliveryFeeCents = split ? (fullDeliveryFeeCents - customerDeliveryFeeCents) : 0;
 		const taxCents = Math.round(itemsTotal * 0.05);
-		const totalCents = itemsTotal + taxCents + deliveryFeeCents;
+    const totalCents = itemsTotal + taxCents + customerDeliveryFeeCents;
 		const trackingUrl = delivery?.tracking_url || delivery?.trackingUrl || delivery?.share_url || delivery?.tracking_url_v2 || '';
 		const deliveryStatus = delivery?.status || delivery?.state || delivery?.current_status || '';
     const orderPayload = {
@@ -125,7 +130,8 @@ router.post('/:slug/create', requireAuth, async (req, res) => {
 			totalCents,
 			taxCents,
 			tipCents: 0,
-			deliveryFeeCents,
+      deliveryFeeCents: customerDeliveryFeeCents,
+      deliveryFeeRestaurantCents: restaurantDeliveryFeeCents,
 			externalId,
 			uberDeliveryId: delivery?.id || delivery?.delivery_id,
       uberTrackingUrl: trackingUrl,
@@ -144,7 +150,7 @@ router.post('/:slug/create', requireAuth, async (req, res) => {
 		} else {
 			await Order.create(orderPayload);
 		}
-		res.status(201).json({ ...delivery, distanceKm, distanceFeeCents, pickupLocationIndex: chosenIdx });
+    res.status(201).json({ ...delivery, distanceKm, distanceFeeCents: fullDeliveryFeeCents, customerDeliveryFeeCents, pickupLocationIndex: chosenIdx });
 	} catch (err) {
 		res.status(400).json({ error: err.message });
 	}

--- a/shop/backend/src/routes/shopOrders.js
+++ b/shop/backend/src/routes/shopOrders.js
@@ -216,7 +216,7 @@ router.get('/:slug/orders/:orderId/pdf', requireUser, async (req, res) => {
 
     doc.moveDown();
     const tax = Number(order.taxCents||0)/100;
-    const delivery = Number(order.deliveryFeeCents||0)/100;
+    const delivery = Number(order.deliveryFeeCents||0)/100; // show only customer's half if split
     const total = Number(order.totalCents||0)/100;
     const valueX = startX + width - 100;
     const labelWidth = 220;

--- a/shop/backend/src/routes/shopPublic.js
+++ b/shop/backend/src/routes/shopPublic.js
@@ -23,7 +23,7 @@ router.use('/:slug', tenantBySlug);
 router.get('/:slug/site', async (req, res) => {
   try {
     const { site } = req;
-    return res.json({ siteId: req.siteId, slug: site.slug, name: site.name, brandColor: site.brandColor, deliveryFeeCents: Number(site.deliveryFeeCents) || 0, logoUrl: site.logoUrl });
+    return res.json({ siteId: req.siteId, slug: site.slug, name: site.name, brandColor: site.brandColor, deliveryFeeCents: Number(site.deliveryFeeCents) || 0, splitDeliveryFee: !!site.splitDeliveryFee, logoUrl: site.logoUrl });
   } catch (err) {
     return res.status(400).json({ error: err.message });
   }

--- a/shop/frontend/src/ShopApp.jsx
+++ b/shop/frontend/src/ShopApp.jsx
@@ -11,6 +11,7 @@ import { FulfillmentModal } from './components/FulfillmentModal';
 import { Modal } from './components/Modal';
 import { SpiceModal } from './components/SpiceModal';
 import { ExtrasModal } from './components/ExtrasModal';
+import { VariantModal } from './components/VariantModal';
 import { AddToCartToast } from './components/AddToCartToast';
 import { DeliveryAddressModal } from './components/DeliveryAddressModal';
 import { fetchJson, getAuthToken } from './lib/api';
@@ -26,7 +27,9 @@ const Main = ({ siteSlug = 'default', initialCategoryId }) => {
   const [pendingQuantity, setPendingQuantity] = useState(1);
   const [spiceOpen, setSpiceOpen] = useState(false);
   const [extrasOpen, setExtrasOpen] = useState(false);
+  const [variantOpen, setVariantOpen] = useState(false);
   const [pendingSpice, setPendingSpice] = useState(undefined);
+  const [pendingVariant, setPendingVariant] = useState(null);
   const [deliveryModalOpen, setDeliveryModalOpen] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
   const [vegFilter, setVegFilter] = useState('all');
@@ -95,7 +98,9 @@ const Main = ({ siteSlug = 'default', initialCategoryId }) => {
   function startAddToCart(product, quantity = 1) {
     setPendingProduct(product);
     setPendingQuantity(Math.max(1, Math.min(99, Number(quantity) || 1)));
-    if (product.spiceLevels && product.spiceLevels.length > 0) {
+    if (Array.isArray(product?.variants) && product.variants.length > 0) {
+      setVariantOpen(true);
+    } else if (product.spiceLevels && product.spiceLevels.length > 0) {
       setSpiceOpen(true);
     } else if (product.extraOptionGroups && product.extraOptionGroups.length > 0) {
       setExtrasOpen(true);
@@ -106,15 +111,31 @@ const Main = ({ siteSlug = 'default', initialCategoryId }) => {
     }
   }
 
+  function confirmVariant(variant) {
+    setPendingVariant(variant || null);
+    setVariantOpen(false);
+    if (pendingProduct && pendingProduct.spiceLevels && pendingProduct.spiceLevels.length > 0) {
+      setSpiceOpen(true);
+    } else if (pendingProduct && pendingProduct.extraOptionGroups && pendingProduct.extraOptionGroups.length > 0) {
+      setExtrasOpen(true);
+    } else if (pendingProduct) {
+      addItem({ product: pendingProduct, variant, spiceLevel: undefined, quantity: pendingQuantity });
+      setPendingProduct(null);
+      setPendingVariant(null);
+      setPendingQuantity(1);
+    }
+  }
+
   function confirmSpice(spice) {
     setPendingSpice(spice);
     setSpiceOpen(false);
     if (pendingProduct && pendingProduct.extraOptionGroups && pendingProduct.extraOptionGroups.length > 0) {
       setExtrasOpen(true);
     } else if (pendingProduct) {
-      addItem({ product: pendingProduct, spiceLevel: spice, quantity: pendingQuantity });
+      addItem({ product: pendingProduct, variant: pendingVariant || undefined, spiceLevel: spice, quantity: pendingQuantity });
       setPendingProduct(null);
       setPendingSpice(undefined);
+      setPendingVariant(null);
       setPendingQuantity(1);
     }
   }
@@ -122,10 +143,11 @@ const Main = ({ siteSlug = 'default', initialCategoryId }) => {
   function confirmExtras(selected) {
     setExtrasOpen(false);
     if (pendingProduct) {
-      addItem({ product: pendingProduct, spiceLevel: pendingSpice, selectedOptions: selected, quantity: pendingQuantity });
+      addItem({ product: pendingProduct, variant: pendingVariant || undefined, spiceLevel: pendingSpice, selectedOptions: selected, quantity: pendingQuantity });
     }
     setPendingProduct(null);
     setPendingSpice(undefined);
+    setPendingVariant(null);
     setPendingQuantity(1);
   }
 
@@ -547,6 +569,7 @@ const Main = ({ siteSlug = 'default', initialCategoryId }) => {
       ) : null}
       <SpiceModal open={spiceOpen} spiceLevels={pendingProduct?.spiceLevels} product={pendingProduct} onCancel={() => setSpiceOpen(false)} onConfirm={confirmSpice} />
       <ExtrasModal open={extrasOpen} groups={pendingProduct?.extraOptionGroups} product={pendingProduct} onCancel={() => setExtrasOpen(false)} onConfirm={confirmExtras} />
+      <VariantModal open={variantOpen} variants={pendingProduct?.variants || []} product={pendingProduct} onCancel={() => setVariantOpen(false)} onConfirm={confirmVariant} />
       <AddToCartToast />
       <UserAuthModal open={loginOpen} onClose={() => setLoginOpen(false)} onSuccess={() => {
         setLoginOpen(false);

--- a/shop/frontend/src/components/AdminDashboard.jsx
+++ b/shop/frontend/src/components/AdminDashboard.jsx
@@ -134,7 +134,7 @@ export const AdminDashboard = () => {
   }, [products, filterCategory, vegFilter]);
 
   function startCreate() {
-    setEditing({ name: '', price: 0, categoryId: categories[0]?._id || '', description: '', imageUrl: '', spiceLevels: [], extraOptionGroups: [] });
+    setEditing({ name: '', price: 0, categoryId: categories[0]?._id || '', description: '', imageUrl: '', spiceLevels: [], variants: [], extraOptionGroups: [] });
   }
 
   function startEdit(p) {
@@ -150,6 +150,7 @@ export const AdminDashboard = () => {
       price: Number(editing.price || 0),
       categoryId: editing.categoryId,
       spiceLevels: editing.spiceLevels || [],
+      variants: editing.variants || [],
       extraOptionGroups: editing.extraOptionGroups || [],
     };
     if (editing._id) {
@@ -400,7 +401,7 @@ export const AdminDashboard = () => {
                   <tbody>
                     {(Array.isArray(orders) ? orders : []).map((o) => {
                       const customer = o.dropoff?.name || o.userEmail || '—';
-                      const itemsText = (Array.isArray(o.items) ? o.items : []).map((it) => `${it.name}${it.spiceLevel ? ` [${it.spiceLevel}]` : ''} × ${it.quantity}`).join(', ');
+                      const itemsText = (Array.isArray(o.items) ? o.items : []).map((it) => `${it.name}${it.spiceLevel ? ` [${it.spiceLevel}]` : ''}${it.size ? ` (${it.size})` : ''} × ${it.quantity}`).join(', ');
                       const tax = ((o.taxCents||0)/100).toFixed(2);
                       const notes = o.notes ? String(o.notes).slice(0, 60) : '';
                       return (
@@ -411,6 +412,9 @@ export const AdminDashboard = () => {
                           <td style={{ padding: '8px 6px', borderBottom: '1px solid var(--border)' }}>
                             <div style={{ fontWeight: 800, color: 'var(--primary-600)' }}>${((o.totalCents||0)/100).toFixed(2)}</div>
                             <div className="muted" style={{ fontSize: 12 }}>Tax: ${tax}</div>
+                            {o.deliveryFeeCents ? (
+                              <div className="muted" style={{ fontSize: 12 }}>Delivery: ${((o.deliveryFeeCents||0)/100).toFixed(2)}{o.deliveryFeeRestaurantCents ? ` (Restaurant: ${((o.deliveryFeeRestaurantCents||0)/100).toFixed(2)})` : ''}</div>
+                            ) : null}
                           </td>
                           <td style={{ padding: '8px 6px', borderBottom: '1px solid var(--border)' }}>{itemsText}</td>
                           <td style={{ padding: '8px 6px', borderBottom: '1px solid var(--border)', textAlign: 'right' }}>
@@ -517,6 +521,19 @@ export const AdminDashboard = () => {
                         }
                       }} />
                     </label>
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    <span>Variants (JSON)</span>
+                    <textarea
+                      rows={4}
+                      value={JSON.stringify(editing.variants || [], null, 2)}
+                      onChange={(e) => {
+                        try {
+                          const parsed = JSON.parse(e.target.value);
+                          setEditing({ ...editing, variants: parsed });
+                        } catch {}
+                      }}
+                    />
                   </div>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
                     <span>Extra option groups (JSON)</span>

--- a/shop/frontend/src/components/CartSidebar.jsx
+++ b/shop/frontend/src/components/CartSidebar.jsx
@@ -73,6 +73,7 @@ export const CartSidebar = ({ open, onClose, onCheckout, readyAt }) => {
                 {item.imageUrl ? <img src={item.imageUrl} alt={item.name} style={{ width: 60, height: 60, objectFit: 'cover', borderRadius: 8 }} /> : null}
                 <div style={{ flex: 1 }}>
                   <div style={{ fontWeight: 700 }}>{item.name}</div>
+                  {item.variant ? <div style={{ fontSize: 12, color: 'var(--muted)' }}>Size: {item.variant.label || item.variant.key}</div> : null}
                   {item.spiceLevel ? <div style={{ fontSize: 12, color: 'var(--muted)' }}>Spice: {item.spiceLevel}</div> : null}
                   {item.selectedOptions.length > 0 ? (
                     <ul style={{ paddingLeft: 18, margin: '6px 0', color: 'var(--text)' }}>

--- a/shop/frontend/src/components/DeliveryAddressModal.jsx
+++ b/shop/frontend/src/components/DeliveryAddressModal.jsx
@@ -15,6 +15,7 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
   const [quote, setQuote] = useState(null);
   const [siteName, setSiteName] = useState('');
   const [deliveryFeeCents, setDeliveryFeeCents] = useState(0);
+  const [splitDeliveryFee, setSplitDeliveryFee] = useState(false);
   const [country, setCountry] = useState('CA');
   const [distanceKm, setDistanceKm] = useState(null);
   const [tab, setTab] = useState('enter'); // delivery: only manual address (enter)
@@ -60,6 +61,7 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
         if (!cancelled) {
           setSiteName(data.name || '');
           setDeliveryFeeCents(Number(data.deliveryFeeCents) || 0);
+          setSplitDeliveryFee(!!data.splitDeliveryFee);
         }
       } catch {}
     }
@@ -120,7 +122,7 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
       const q = await postJson(`/api/delivery/${siteSlug}/quote`, { dropoff: { name, phone, address }, pickupLocationIndex: selectedPickupIndex });
       setQuote(q);
       if (typeof q?.distanceKm === 'number') setDistanceKm(q.distanceKm);
-      if (typeof q?.distanceFeeCents === 'number') setDeliveryFeeCents(q.distanceFeeCents);
+      if (typeof q?.customerDeliveryFeeCents === 'number') setDeliveryFeeCents(q.customerDeliveryFeeCents);
     } catch (e) {
       setError(parseServerError(e) || 'Failed to get quote');
     } finally { setLoading(false); }
@@ -214,14 +216,9 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
                 <span style={{ fontWeight: 700 }}>${((itemsSubtotalCents*0.05)/100).toFixed(2)}</span>
               </div>
             <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
-              <span className="muted">Delivery fee</span>
+              <span className="muted">Delivery fee{splitDeliveryFee ? ' (your share)' : ''}</span>
               <span style={{ fontWeight: 700 }}>{deliveryFeeCents ? `$${(deliveryFeeCents/100).toFixed(2)}` : '—'}</span>
             </div>
-            {typeof distanceKm === 'number' ? (
-              <div className="muted" style={{ fontSize: 12, marginTop: -2, marginBottom: 6 }}>
-                Distance: {distanceKm.toFixed(1)} km (first 8 km = $8, +$1/km after)
-              </div>
-            ) : null}
             <div style={{ height: 1, background: 'var(--border)', margin: '6px 0' }} />
             {quote?.dropoff_estimated_dt ? (
               <div className="muted" style={{ fontSize: 12, marginBottom: 6 }}>ETA: {new Date(quote.dropoff_estimated_dt).toLocaleTimeString()}</div>

--- a/shop/frontend/src/components/SiteSettingsPanel.jsx
+++ b/shop/frontend/src/components/SiteSettingsPanel.jsx
@@ -16,6 +16,7 @@ export const SiteSettingsPanel = ({ site, selectedSiteId, onSiteUpdated }) => {
   const [locations, setLocations] = React.useState(Array.isArray(site?.locations) ? site.locations : []);
   const [cities, setCities] = React.useState(Array.isArray(site?.cities) ? site.cities : []);
   const [deliveryFee, setDeliveryFee] = React.useState(((Number(site?.deliveryFeeCents)||0)/100).toFixed(2));
+  const [splitDeliveryFee, setSplitDeliveryFee] = React.useState(!!site?.splitDeliveryFee);
   const [logoUrl, setLogoUrl] = React.useState(site?.logoUrl || '');
   const [logoFile, setLogoFile] = React.useState(null);
   const [hours, setHours] = React.useState(site?.hours || {
@@ -51,6 +52,7 @@ export const SiteSettingsPanel = ({ site, selectedSiteId, onSiteUpdated }) => {
     setLocations(Array.isArray(site?.locations) ? site.locations : []);
     setCities(Array.isArray(site?.cities) ? site.cities : []);
     setDeliveryFee(((Number(site?.deliveryFeeCents)||0)/100).toFixed(2));
+    setSplitDeliveryFee(!!site?.splitDeliveryFee);
     setHours(site?.hours || {
       mon: { open: '10:00', close: '22:00', closed: false },
       tue: { open: '10:00', close: '22:00', closed: false },
@@ -136,6 +138,10 @@ export const SiteSettingsPanel = ({ site, selectedSiteId, onSiteUpdated }) => {
         <span>Flat delivery fee (in $)</span>
         <input type="number" step="0.01" min={0} value={deliveryFee} onChange={(e) => setDeliveryFee(e.target.value)} />
         <span className="muted" style={{ fontSize: 12 }}>Applied only to delivery orders. Not shown for pickup.</span>
+      </label>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input type="checkbox" checked={!!splitDeliveryFee} onChange={(e) => setSplitDeliveryFee(e.target.checked)} />
+        <span>Split delivery fee 50/50 (half customer, half restaurant)</span>
       </label>
 
       <div style={{ gridColumn: '1 / -1', fontWeight: 800, marginTop: 8 }}>Opening hours</div>
@@ -240,6 +246,7 @@ export const SiteSettingsPanel = ({ site, selectedSiteId, onSiteUpdated }) => {
             locations,
             cities,
             deliveryFeeCents: Math.max(0, Math.round(Number(deliveryFee || 0) * 100)),
+            splitDeliveryFee: !!splitDeliveryFee,
             hours,
             logoUrl,
             pickup: {

--- a/shop/frontend/src/components/VariantModal.jsx
+++ b/shop/frontend/src/components/VariantModal.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Modal } from './Modal';
+
+export const VariantModal = ({ open, variants = [], onCancel, onConfirm, product }) => {
+  const [selectedKey, setSelectedKey] = useState('');
+
+  const selected = variants.find((v) => v.key === selectedKey) || null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onCancel}
+      title={null}
+      footer={(
+        <div style={{ display: 'flex', justifyContent: 'center', gap: 12 }}>
+          <button onClick={onCancel} style={{ padding: '10px 14px', borderRadius: 10, border: '1px solid var(--border)', background: 'var(--panel-2)' }}>Cancel</button>
+          <button onClick={() => onConfirm(selected)} disabled={!selected} className="primary-btn" style={{ padding: '10px 14px', borderRadius: 10, minWidth: 140, opacity: selected ? 1 : 0.7 }}>OK</button>
+        </div>
+      )}
+    >
+      {product ? (
+        <div style={{ position: 'relative', height: 160, borderRadius: 14, overflow: 'hidden', border: '1px solid var(--border)', marginBottom: 12 }}>
+          {product.imageUrl ? (
+            <img src={product.imageUrl} alt={product.name} className="img-cover" />
+          ) : (
+            <div style={{ width: '100%', height: '100%', display: 'grid', placeItems: 'center', fontSize: 42, background: 'var(--primary-alpha-08)' }}>🧩</div>
+          )}
+          <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(2,6,23,0.00), rgba(2,6,23,0.35))' }} />
+          <div style={{ position: 'absolute', left: 12, bottom: 12, right: 12, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div style={{ fontWeight: 900, fontSize: 18, color: '#fff', textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}>{product.name}</div>
+            <div style={{ fontWeight: 900, color: '#fff', textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}>${product.price.toFixed(2)}</div>
+          </div>
+        </div>
+      ) : null}
+      <div style={{ fontWeight: 800, marginBottom: 6 }}>Choose a variant</div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 10 }}>
+        {variants.map((v) => {
+          const active = selectedKey === v.key;
+          return (
+            <button
+              key={v.key}
+              onClick={() => setSelectedKey(v.key)}
+              className="image-choice"
+              data-active={active}
+              style={{ padding: 12, borderRadius: 12, border: active ? '2px solid var(--primary-600)' : '1px solid var(--border)', background: active ? 'rgba(14,165,233,0.12)' : 'var(--panel)' }}
+            >
+              <div style={{ fontWeight: 800 }}>{v.label}</div>
+              <div className="muted" style={{ fontSize: 12 }}>{v.priceDelta ? `+ $${Number(v.priceDelta).toFixed(2)}` : 'No extra cost'}</div>
+            </button>
+          );
+        })}
+      </div>
+    </Modal>
+  );
+};
+

--- a/shop/frontend/src/pages/MyOrdersPage.jsx
+++ b/shop/frontend/src/pages/MyOrdersPage.jsx
@@ -106,7 +106,9 @@ export const MyOrdersPage = () => {
               <div className="muted" style={{ fontSize: 12, marginTop: 4 }}>{o.fulfillmentType === 'delivery' ? 'Delivery' : 'Pickup'}</div>
               <ul style={{ margin: '8px 0', paddingLeft: 18 }}>
                 {(Array.isArray(o.items) ? o.items : []).map((it, idx) => (
-                  <li key={idx}>{it.name} × {it.quantity}</li>
+                  <li key={idx}>
+                    {it.name}{it.spiceLevel ? ` [${it.spiceLevel}]` : ''}{it.size ? ` (${it.size})` : ''} × {it.quantity}
+                  </li>
                 ))}
               </ul>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/shop/frontend/src/store/CartContext.jsx
+++ b/shop/frontend/src/store/CartContext.jsx
@@ -8,7 +8,7 @@ function calculateExtraCost(selectedOptions) {
   return (selectedOptions || []).reduce((sum, opt) => sum + (opt.priceDelta || 0), 0);
 }
 
-function formatOptionsSummary(product, spiceLevel, selectedOptions) {
+function formatOptionsSummary(product, spiceLevel, selectedOptions, variant) {
   try {
     const groups = Array.isArray(product?.extraOptionGroups) ? product.extraOptionGroups : [];
     const groupKeyToLabel = new Map(groups.map((g) => [g.groupKey, g.groupLabel || g.groupKey]));
@@ -23,6 +23,7 @@ function formatOptionsSummary(product, spiceLevel, selectedOptions) {
     });
 
     const parts = [];
+    if (variant && (variant.label || variant.key)) parts.push(`Size: ${variant.label || variant.key}`);
     if (spiceLevel) parts.push(`Spice: ${spiceLevel}`);
     for (const [gk, labels] of perGroupSelections.entries()) {
       const glabel = groupKeyToLabel.get(gk) || gk;
@@ -35,13 +36,14 @@ function formatOptionsSummary(product, spiceLevel, selectedOptions) {
   }
 }
 
-function generateItemId(productId, spiceLevel, selectedOptions) {
+function generateItemId(productId, spiceLevel, selectedOptions, variant) {
   const optsKey = (selectedOptions || [])
     .slice()
     .sort((a, b) => `${a.groupKey}:${a.optionKey}`.localeCompare(`${b.groupKey}:${b.optionKey}`))
     .map((o) => `${o.groupKey}:${o.optionKey}`)
     .join('|');
-  return `${productId}__${spiceLevel || ''}__${optsKey}`;
+  const variantKey = variant?.key || '';
+  return `${productId}__${variantKey}__${spiceLevel || ''}__${optsKey}`;
 }
 
 export const CartProvider = ({ children, storageKey = DEFAULT_STORAGE_KEY }) => {
@@ -80,15 +82,18 @@ export const CartProvider = ({ children, storageKey = DEFAULT_STORAGE_KEY }) => 
 
   const clearCoupon = useCallback(() => setState((prev) => ({ ...prev, coupon: null })), []);
 
-  const addItem = useCallback(({ product, quantity = 1, spiceLevel, selectedOptions = [] }) => {
+  const addItem = useCallback(({ product, quantity = 1, spiceLevel, selectedOptions = [], variant = null }) => {
     const extraCost = calculateExtraCost(selectedOptions);
-    const totalPrice = (product.price + extraCost) * quantity;
-    const id = generateItemId(product._id, spiceLevel, selectedOptions);
+    const variantDelta = variant?.priceDelta || 0;
+    const unitPrice = product.price + variantDelta + extraCost;
+    const totalPrice = unitPrice * quantity;
+    const id = generateItemId(product._id, spiceLevel, selectedOptions, variant);
     const newItem = {
       id,
       productId: product._id,
       name: product.name,
       basePrice: product.price,
+      variant,
       quantity,
       spiceLevel,
       selectedOptions,
@@ -106,14 +111,14 @@ export const CartProvider = ({ children, storageKey = DEFAULT_STORAGE_KEY }) => 
         updated[existingIndex] = {
           ...existing,
           quantity: newQuantity,
-          totalPrice: (existing.basePrice + existing.extraCost) * newQuantity,
+          totalPrice: (existing.basePrice + (existing?.variant?.priceDelta || 0) + existing.extraCost) * newQuantity,
         };
         return { ...prev, items: updated };
       }
       return { ...prev, items: [...prev.items, newItem] };
     });
-    const optionsSummary = formatOptionsSummary(product, spiceLevel, selectedOptions);
-    setLastAdded({ name: product.name, quantity, price: (product.price + extraCost), imageUrl: product.imageUrl, optionsSummary });
+    const optionsSummary = formatOptionsSummary(product, spiceLevel, selectedOptions, variant);
+    setLastAdded({ name: product.name, quantity, price: (product.price + variantDelta + extraCost), imageUrl: product.imageUrl, optionsSummary });
   }, []);
 
   const removeItem = useCallback((id) => {


### PR DESCRIPTION
Implement split delivery fee toggle, add product variants, and enhance order display for spice levels and variants.

This PR addresses multiple user requests:
1.  **Delivery Fee Split:** A new site-level toggle allows splitting delivery fees 50/50 between the customer and restaurant. The customer only sees their half on checkout and in their order PDF, while the admin panel and admin PDF show both halves with specific labels. The checkout modal also hides the distance breakdown.
2.  **Product Variants:** Adds support for product variants (e.g., sizes) with price deltas. Admins can define variants via a JSON field, and customers select them via a new modal after adding a product. Variants are reflected in the cart and order details.
3.  **Spice Level Visibility:** Ensures spice levels are displayed in the admin orders list, my orders page, and order PDFs.

---
<a href="https://cursor.com/background-agent?bcId=bc-108523b5-b995-4032-b766-f6ff06bc33e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-108523b5-b995-4032-b766-f6ff06bc33e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

