### PR TITLE
Fix uber create error 400 field conversion

### DIFF
--- a/shop/backend/src/services/uberDirect.js
+++ b/shop/backend/src/services/uberDirect.js
@@ -120,7 +120,8 @@ function sanitizeManifestItems(items) {
 			const quantityNum = Number(m?.quantity);
 			const quantity = Number.isFinite(quantityNum) && quantityNum > 0 ? Math.floor(quantityNum) : 1;
 			const out = { name, quantity };
-			const rawSize = typeof m?.size === 'string' ? m.size.trim().toLowerCase() : '';
+			const rawSizeLabel = typeof m?.size === 'string' ? m.size.trim() : '';
+			const rawSize = rawSizeLabel ? rawSizeLabel.toLowerCase() : '';
 			let normalizedSize = '';
 			if (rawSize) {
 				if (['s', 'sm'].includes(rawSize)) normalizedSize = 'small';
@@ -129,6 +130,10 @@ function sanitizeManifestItems(items) {
 			}
 			if (normalizedSize && allowedSizes.has(normalizedSize)) {
 				out.size = normalizedSize;
+			} else if (rawSizeLabel) {
+				// Preserve non-size variant labels by appending to the item name,
+				// while ensuring we never send an unsupported size enum to Uber.
+				out.name = `${name} (${rawSizeLabel})`;
 			}
 			return out;
 		});


### PR DESCRIPTION
Prevent Uber delivery creation failures by sanitizing `manifest_items.size` to only send supported enum values, appending unrecognized labels to the item name.

---
<a href="https://cursor.com/background-agent?bcId=bc-000259e1-40cd-430c-bb9d-1871f9b93c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-000259e1-40cd-430c-bb9d-1871f9b93c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

