### PR TITLE
Fix phone number formatting error

### DIFF
--- a/shop/backend/src/routes/delivery.js
+++ b/shop/backend/src/routes/delivery.js
@@ -36,6 +36,12 @@ function normalizePhoneForCountry(raw, country) {
 			national = national.replace(/^0+/, '');
 		}
 		if (defaultCc) {
+			// Special handling for Canada/US: treat 11 digits starting with 1 as full intl already,
+			// and 10 digits as local North American Numbering Plan.
+			if (defaultCc === '1') {
+				if (/^1\d{10}$/.test(national)) return '+' + national;
+				if (/^\d{10}$/.test(national)) return '+1' + national;
+			}
 			const combined = '+' + defaultCc + national;
 			return /^\+[1-9]\d{7,14}$/.test(combined) ? combined : '';
 		}

--- a/shop/backend/src/routes/delivery.js
+++ b/shop/backend/src/routes/delivery.js
@@ -9,6 +9,44 @@ import { distanceBetweenAddressesKm, calculateDistanceFeeCents } from '../servic
 
 const router = Router();
 
+// Normalize a raw phone number to E.164 using the provided country code
+// Supports common cases for CA/US (+1), IN (+91), GB (+44), AU (+61)
+function normalizePhoneForCountry(raw, country) {
+	try {
+		const cleaned = String(raw || '').replace(/[^\d+]/g, '');
+		const c = String(country || 'CA').toUpperCase();
+		const ccMap = { CA: '1', US: '1', IN: '91', GB: '44', AU: '61' };
+		const usesTrunkZero = new Set(['GB', 'IN', 'AU']);
+		const defaultCc = ccMap[c] || '';
+		if (!cleaned) return '';
+		if (cleaned.startsWith('+')) {
+			let withPlus = '+' + cleaned.replace(/\+/g, '');
+			// Drop a single trunk '0' immediately after country code for countries that use it
+			if (defaultCc && usesTrunkZero.has(c)) {
+				const afterCcIdx = 1 + defaultCc.length;
+				if (withPlus.slice(1, afterCcIdx) === defaultCc && withPlus[afterCcIdx] === '0') {
+					withPlus = '+' + defaultCc + withPlus.slice(afterCcIdx + 1);
+				}
+			}
+			return /^\+[1-9]\d{7,14}$/.test(withPlus) ? withPlus : '';
+		}
+		// No plus provided: assume selected country, strip trunk '0' if applicable
+		let national = cleaned;
+		if (usesTrunkZero.has(c) && national.startsWith('0')) {
+			national = national.replace(/^0+/, '');
+		}
+		if (defaultCc) {
+			const combined = '+' + defaultCc + national;
+			return /^\+[1-9]\d{7,14}$/.test(combined) ? combined : '';
+		}
+		// Fallback: if already looks like an international number without plus, add it
+		if (/^[1-9]\d{7,14}$/.test(national)) return '+' + national;
+		return '';
+	} catch {
+		return '';
+	}
+}
+
 router.use('/:slug', tenantBySlug);
 
 router.post('/:slug/quote', async (req, res) => {
@@ -101,12 +139,13 @@ router.post('/:slug/create', requireAuth, async (req, res) => {
       ...pickup,
       phone: /^\+[1-9]\d{7,14}$/.test(normalizedPickupPhone) ? normalizedPickupPhone : '+14155550123',
     };
-		// Sanitize dropoff phone; require valid E.164 from client
-		const dropoffPhone = String(dropoff?.phone || '').replace(/[^\d+]/g, '');
-		if (!/^\+?[1-9]\d{7,14}$/.test(dropoffPhone)) {
-			return res.status(400).json({ error: 'Enter phone as +1XXXXXXXXXX' });
+		// Normalize dropoff phone to E.164 using dropoff country
+		const dropCountry = String(dropoff?.address?.country || 'CA').toUpperCase();
+		const normalizedDropoffPhone = normalizePhoneForCountry(dropoff?.phone, dropCountry);
+		if (!normalizedDropoffPhone) {
+			return res.status(400).json({ error: 'Phone number is invalid. Use E.164 format like +14155550123.' });
 		}
-		const safeDropoff = { ...dropoff, phone: dropoffPhone.startsWith('+') ? dropoffPhone : ('+' + dropoffPhone) };
+		const safeDropoff = { ...dropoff, phone: normalizedDropoffPhone };
 		// Compute distance-based fee
 		let distanceKm = null;
 		try { distanceKm = await distanceBetweenAddressesKm(pickup.address, dropoff.address); } catch {}

--- a/shop/frontend/src/components/DeliveryAddressModal.jsx
+++ b/shop/frontend/src/components/DeliveryAddressModal.jsx
@@ -100,6 +100,35 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
     return /^\+?[1-9]\d{7,14}$/.test(ph.replace(/[^\d+]/g, ''));
   }
 
+  function normalizePhoneForCountry(raw, countryCode) {
+    try {
+      const cleaned = String(raw || '').replace(/[^\d+]/g, '');
+      const c = String(countryCode || 'CA').toUpperCase();
+      const ccMap = { CA: '1', US: '1', IN: '91', GB: '44', AU: '61' };
+      const usesTrunkZero = new Set(['GB', 'IN', 'AU']);
+      const defaultCc = ccMap[c] || '';
+      if (!cleaned) return '';
+      if (cleaned.startsWith('+')) {
+        let withPlus = '+' + cleaned.replace(/\+/g, '');
+        if (defaultCc && usesTrunkZero.has(c)) {
+          const afterCcIdx = 1 + defaultCc.length;
+          if (withPlus.slice(1, afterCcIdx) === defaultCc && withPlus[afterCcIdx] === '0') {
+            withPlus = '+' + defaultCc + withPlus.slice(afterCcIdx + 1);
+          }
+        }
+        return /^\+[1-9]\d{7,14}$/.test(withPlus) ? withPlus : '';
+      }
+      let national = cleaned;
+      if (usesTrunkZero.has(c) && national.startsWith('0')) national = national.replace(/^0+/, '');
+      if (defaultCc) {
+        const combined = '+' + defaultCc + national;
+        return /^\+[1-9]\d{7,14}$/.test(combined) ? combined : '';
+      }
+      if (/^[1-9]\d{7,14}$/.test(national)) return '+' + national;
+      return '';
+    } catch { return ''; }
+  }
+
   function validate() {
     if (!name.trim()) return 'Name is required';
     if (!isValidPhone(phone)) return 'Enter phone as +1XXXXXXXXXX';
@@ -119,7 +148,8 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
         if (invalid) { setError(invalid); setLoading(false); return; }
         address = { streetAddress: [addr1, ...(addr2 ? [addr2] : [])], city, province, postalCode, country };
       }
-      const q = await postJson(`/api/delivery/${siteSlug}/quote`, { dropoff: { name, phone, address }, pickupLocationIndex: selectedPickupIndex });
+      const normalizedPhone = normalizePhoneForCountry(phone, country);
+      const q = await postJson(`/api/delivery/${siteSlug}/quote`, { dropoff: { name, phone: normalizedPhone || phone, address }, pickupLocationIndex: selectedPickupIndex });
       setQuote(q);
       if (typeof q?.distanceKm === 'number') setDistanceKm(q.distanceKm);
       if (typeof q?.customerDeliveryFeeCents === 'number') setDeliveryFeeCents(q.customerDeliveryFeeCents);
@@ -133,8 +163,9 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
     setLoading(true); setError(undefined);
     try {
       const address = { streetAddress: [addr1, ...(addr2 ? [addr2] : [])], city, province, postalCode, country };
+      const normalizedPhone = normalizePhoneForCountry(phone, country);
       const result = await postJson(`/api/delivery/${siteSlug}/create`, {
-        dropoff: { name, phone, address },
+        dropoff: { name, phone: normalizedPhone || phone, address },
         manifestItems: manifest.map(m => ({ name: m.name, quantity: m.quantity, size: m.size, price: m.priceCents || 0, spiceLevel: m.spiceLevel })),
         externalId: `${siteName ? siteName.replace(/\s+/g, '-') : siteSlug}-order-${Date.now()}`,
         pickupLocationIndex: (quote && typeof quote.pickupLocationIndex === 'number') ? quote.pickupLocationIndex : selectedPickupIndex,

--- a/shop/frontend/src/components/DeliveryAddressModal.jsx
+++ b/shop/frontend/src/components/DeliveryAddressModal.jsx
@@ -121,6 +121,10 @@ export const DeliveryAddressModal = ({ open, siteSlug, onClose, onConfirmed, man
       let national = cleaned;
       if (usesTrunkZero.has(c) && national.startsWith('0')) national = national.replace(/^0+/, '');
       if (defaultCc) {
+        if (defaultCc === '1') {
+          if (/^1\d{10}$/.test(national)) return '+' + national;
+          if (/^\d{10}$/.test(national)) return '+1' + national;
+        }
         const combined = '+' + defaultCc + national;
         return /^\+[1-9]\d{7,14}$/.test(combined) ? combined : '';
       }


### PR DESCRIPTION
Implement E.164 phone number normalization on both frontend and backend to resolve invalid phone number errors.

The delivery creation endpoint strictly requires E.164 format, leading to 400 errors for valid local phone number inputs. This change adds logic to automatically convert common local formats (e.g., `780-555-0123` with country `CA`) to E.164 (e.g., `+17805550123`) before sending requests to the backend and before processing them.

---
<a href="https://cursor.com/background-agent?bcId=bc-77d1660f-6dbe-497e-bdb6-ca6528b9c959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77d1660f-6dbe-497e-bdb6-ca6528b9c959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

