### PR TITLE
Update category icons and cart visibility

### DIFF
--- a/shop/frontend/src/ShopApp.jsx
+++ b/shop/frontend/src/ShopApp.jsx
@@ -588,7 +588,14 @@ const Main = ({ siteSlug = 'default', initialCategoryId }) => {
       {lastDeliveryId ? (
         <div className="muted" style={{ textAlign: 'center', marginTop: 10, fontSize: 12 }}>Last delivery ID: {lastDeliveryId}</div>
       ) : null}
-      <SpiceModal open={spiceOpen} spiceLevels={pendingProduct?.spiceLevels} product={pendingProduct} onCancel={() => setSpiceOpen(false)} onConfirm={confirmSpice} />
+      <SpiceModal
+        open={spiceOpen}
+        spiceLevels={pendingProduct?.spiceLevels}
+        product={pendingProduct}
+        category={(pendingProduct && allCategories.find(c => String(c._id) === String(pendingProduct.categoryId))) || selectedCategory || null}
+        onCancel={() => setSpiceOpen(false)}
+        onConfirm={confirmSpice}
+      />
       <ExtrasModal open={extrasOpen} groups={pendingProduct?.extraOptionGroups} product={pendingProduct} onCancel={() => setExtrasOpen(false)} onConfirm={confirmExtras} />
       <VariantModal open={variantOpen} variants={pendingProduct?.variants || []} product={pendingProduct} onCancel={() => setVariantOpen(false)} onConfirm={confirmVariant} />
       <AddToCartToast />

--- a/shop/frontend/src/components/SpiceModal.jsx
+++ b/shop/frontend/src/components/SpiceModal.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Modal } from './Modal';
 import { normalizeSpiceLevel } from '../lib/assetFinder';
+import { resolveAssetUrl } from '../lib/api';
 // Explicit imports for spice level images (preferred usage)
 // If these files are removed/renamed, the code will gracefully fall back to dynamic lookup
 import mildImg from '../assets/mild.png';
@@ -8,7 +9,7 @@ import mediumImg from '../assets/medium.png';
 import hotImg from '../assets/Hot.png';
 import extraHotImg from '../assets/extra hot.png';
 
-export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) => {
+export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product, category }) => {
   const [selected, setSelected] = useState(undefined);
   const baseDefaults = ['Mild', 'Medium', 'Hot'];
   // Dedupe by canonical name and keep a stable order (single set of options)
@@ -50,9 +51,13 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
       {product ? (
         <div style={{ position: 'relative', height: 200, borderRadius: 14, overflow: 'hidden', border: '1px solid var(--border)', marginBottom: 12 }}>
           {product.imageUrl ? (
-            <img src={product.imageUrl} alt={product.name} className="img-cover" />
+            <img src={resolveAssetUrl(product.imageUrl)} alt={product.name} className="img-cover" />
           ) : (
-            <div style={{ width: '100%', height: '100%', display: 'grid', placeItems: 'center', fontSize: 42, background: 'var(--primary-alpha-08)' }}>🌶️</div>
+            category?.imageUrl ? (
+              <img src={resolveAssetUrl(category.imageUrl)} alt={category?.name || 'Category'} className="img-cover" />
+            ) : (
+              <div style={{ width: '100%', height: '100%', display: 'grid', placeItems: 'center', fontSize: 42, background: 'var(--primary-alpha-08)' }}>🌶️</div>
+            )
           )}
           <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(2,6,23,0.00), rgba(2,6,23,0.35))' }} />
           <div style={{ position: 'absolute', left: 12, bottom: 12, right: 12, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -82,7 +87,16 @@ export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product }) 
                     decoding="async"
                   />
                 ) : (
-                  <div style={{ fontSize: 42 }}>🌶️</div>
+                  category?.imageUrl ? (
+                    <img
+                      src={resolveAssetUrl(category.imageUrl)}
+                      alt={category?.name || 'Category'}
+                      loading="eager"
+                      decoding="async"
+                    />
+                  ) : (
+                    <div style={{ fontSize: 42 }}>🌶️</div>
+                  )
                 )}
               </div>
             </button>


### PR DESCRIPTION
Replace chili icon with category image fallback in product spice popup.

The product spice modal now uses the product's category image as a fallback when a product or specific spice level image is not available. The requested cart icon responsive visibility (hidden on desktop, visible on mobile/tablet) was confirmed to be already implemented.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9771326-8f31-439c-8d49-3eea15ee34b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9771326-8f31-439c-8d49-3eea15ee34b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

