### PR TITLE
Fix stripe integration and admin panel settings

### DIFF
--- a/shop/frontend/src/components/SpiceModal.jsx
+++ b/shop/frontend/src/components/SpiceModal.jsx
@@ -1,20 +1,15 @@
 import React, { useMemo, useState } from 'react';
 import { Modal } from './Modal';
-import { getSpiceBadge, normalizeSpiceLevel } from '../lib/assetFinder';
+import { getSpiceBadge } from '../lib/assetFinder';
 
 // Show the site's logo instead of chilli icons for spice options
 export const SpiceModal = ({ open, spiceLevels, onCancel, onConfirm, product, siteLogoSrc }) => {
   const [selected, setSelected] = useState(undefined);
 
   const levels = useMemo(() => {
-    const defaults = ['mild', 'medium', 'hot', 'extra-hot'];
-    try {
-      const raw = Array.isArray(spiceLevels) ? spiceLevels : Array.isArray(product?.spiceLevels) ? product.spiceLevels : [];
-      const canonical = raw.map((lvl) => normalizeSpiceLevel(lvl));
-      const unique = Array.from(new Set(canonical)).filter(Boolean);
-      return unique.length ? unique : defaults;
-    } catch { return defaults; }
-  }, [spiceLevels, product && product.spiceLevels && product.spiceLevels.length]);
+    // Always show full set to ensure consistency across products
+    return ['mild', 'medium', 'hot', 'extra-hot'];
+  }, []);
 
   // Resolve per-level image from assets; fallback to site's logo if provided
   const getSpiceImage = (level) => {


### PR DESCRIPTION
Always show all four spice levels (Mild, Medium, Hot, Extra Hot) in the spice selection modal.

This fixes an issue where the modal would sometimes only display two spice levels if the product data was incomplete or malformed.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bc47a90-d469-4947-a5c5-4523f5a96881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3bc47a90-d469-4947-a5c5-4523f5a96881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

