### PR TITLE
Fix image categorization for mild and hot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4637,6 +4637,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
@@ -6709,6 +6718,7 @@
         "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "node-fetch": "^3.3.2",
+        "nodemailer": "^6.9.14",
         "pdfkit": "^0.15.2",
         "stripe": "^16.12.0",
         "xlsx": "^0.18.5"

--- a/shop/frontend/src/lib/assetFinder.js
+++ b/shop/frontend/src/lib/assetFinder.js
@@ -60,9 +60,12 @@ const canonicalToExactSpice = {
  * Find the best-matching asset by checking if the filename contains
  * any of the provided keywords (case-insensitive). Returns the URL or undefined.
  */
-export function findAssetByKeywords(keywords) {
+export function findAssetByKeywords(keywords, options = {}) {
   if (!Array.isArray(keywords) || keywords.length === 0) return undefined;
   const lowered = keywords.map((k) => String(k || '').toLowerCase());
+  const excludeList = Array.isArray(options.exclude)
+    ? options.exclude.map((k) => String(k || '').toLowerCase())
+    : [];
 
   // 1) Prefer exact filename matches for common names
   //    Accept both with and without extension, and allow spaces/underscores/hyphens
@@ -92,17 +95,29 @@ export function findAssetByKeywords(keywords) {
   let best = undefined;
   let bestScore = 0;
   for (const asset of allAssets) {
+    const filename = asset.filename;
+    // Exclude filenames that contain any excluded tokens
+    if (excludeList.length > 0) {
+      let isExcluded = false;
+      for (const ex of excludeList) {
+        if (!ex) continue;
+        if (filename.includes(ex)) { isExcluded = true; break; }
+      }
+      if (isExcluded) continue;
+    }
+
     let score = 0;
     for (const key of lowered) {
       if (!key) continue;
-      if (asset.filename.includes(key)) score += 1;
+      if (filename.includes(key)) score += 1;
     }
     if (score > bestScore) {
       best = asset;
       bestScore = score;
     }
   }
-  return best?.url;
+  // Only return a result if at least one keyword matched
+  return bestScore > 0 ? best?.url : undefined;
 }
 
 // --- Fuzzy helpers for robust spice detection ---
@@ -221,19 +236,31 @@ export function getSpiceBadge(level) {
   if (canonical === 'hot') {
     return (
       tryExactBaseNames(['hot', 'chilli-red', 'chili-red']) ||
-      findAssetByKeywords(['hot', 'spicy', 'level3', 'lvl3', '3', 'spice', 'red', 'chilli', 'pepper'])
+      // Avoid selecting extra-hot variants when looking for hot
+      findAssetByKeywords(
+        ['hot', 'spicy', 'level3', 'lvl3', '3', 'spice', 'red', 'chilli', 'pepper'],
+        { exclude: ['extra', 'xhot', 'x-hot', 'xxhot', 'xx-hot'] }
+      )
     );
   }
   if (canonical === 'medium') {
     return (
       tryExactBaseNames(['medium', 'chilli-orange', 'chili-orange']) ||
-      findAssetByKeywords(['medium', 'moderate', 'level2', 'lvl2', '2', 'spice', 'orange'])
+      // Avoid mild/hot/extra-hot and off-color picks
+      findAssetByKeywords(
+        ['medium', 'moderate', 'level2', 'lvl2', '2', 'spice', 'orange'],
+        { exclude: ['mild', 'hot', 'extra', 'xhot', 'x-hot', 'xxhot', 'xx-hot', 'red', 'green'] }
+      )
     );
   }
   // default/mild
   return (
     tryExactBaseNames(['mild', 'chilli-green', 'chili-green']) ||
-    findAssetByKeywords(['mild', 'low', 'level1', 'lvl1', '1', 'spice', 'green'])
+    // Avoid medium/hot/extra-hot and off-color picks
+    findAssetByKeywords(
+      ['mild', 'low', 'level1', 'lvl1', '1', 'spice', 'green'],
+      { exclude: ['medium', 'hot', 'extra', 'xhot', 'x-hot', 'xxhot', 'xx-hot', 'red', 'orange'] }
+    )
   );
 }
 


### PR DESCRIPTION
Refine spice level image selection to prevent incorrect images from being displayed for mild, medium, and hot categories.

The previous image selection logic could sometimes return a less-than-ideal match or a fallback, leading to "medium" images appearing for "mild" and "extra hot" images for "hot". This PR introduces an `exclude` option for `findAssetByKeywords` and ensures a match score greater than zero, along with specific exclusions for each spice level, to ensure more accurate image mapping.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f24e87b-4a93-41d2-b9f6-dbd68d0fa78e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f24e87b-4a93-41d2-b9f6-dbd68d0fa78e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

